### PR TITLE
27-industrynaics-capture-endpoint-accept-multiple-naics-codes-db-modelmigration-optional-description

### DIFF
--- a/alembic/versions/f3d9f2b7a1c4_add_industry_profile_naics_codes.py
+++ b/alembic/versions/f3d9f2b7a1c4_add_industry_profile_naics_codes.py
@@ -1,0 +1,108 @@
+"""add industry profile naics codes
+
+Revision ID: f3d9f2b7a1c4
+Revises: b9c822df01c0
+Create Date: 2026-02-26 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "f3d9f2b7a1c4"
+down_revision: Union[str, None] = "b9c822df01c0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "industry_profiles",
+        sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+        sa.Column("company_id", sa.Integer, nullable=False),
+        sa.Column("province", sa.String(50), nullable=True),
+        sa.Column("business_description", sa.Text, nullable=True),
+        sa.Column("created_at", sa.DateTime, nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime, nullable=False, server_default=sa.func.now()),
+        sa.UniqueConstraint("company_id", name="uq_industry_profiles_company_id"),
+    )
+    op.create_index("ix_industry_profiles_company_id", "industry_profiles", ["company_id"])
+    op.create_foreign_key(
+        "fk_industry_profiles_company_id",
+        "industry_profiles",
+        "company",
+        ["company_id"],
+        ["id"],
+        ondelete="CASCADE",
+        onupdate="CASCADE",
+    )
+
+    op.create_table(
+        "industry_naics_codes",
+        sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+        sa.Column("industry_profile_id", sa.Integer, nullable=False),
+        sa.Column("code", sa.String(6), nullable=False),
+        sa.Column("position", sa.Integer, nullable=False),
+        sa.Column("created_at", sa.DateTime, nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime, nullable=False, server_default=sa.func.now()),
+        sa.UniqueConstraint("industry_profile_id", "code", name="uq_industry_naics_profile_code"),
+    )
+    op.create_index("ix_industry_naics_codes_industry_profile_id", "industry_naics_codes", ["industry_profile_id"])
+    op.create_foreign_key(
+        "fk_industry_naics_codes_profile_id",
+        "industry_naics_codes",
+        "industry_profiles",
+        ["industry_profile_id"],
+        ["id"],
+        ondelete="CASCADE",
+        onupdate="CASCADE",
+    )
+
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    company_columns = {column["name"] for column in inspector.get_columns("company")}
+
+    has_legacy_province = "province" in company_columns
+    has_legacy_business_description = "business_description" in company_columns
+    has_legacy_naics_code = "naics_code" in company_columns
+
+    if has_legacy_province or has_legacy_business_description or has_legacy_naics_code:
+        province_expr = "province" if has_legacy_province else "NULL"
+        business_description_expr = "business_description" if has_legacy_business_description else "NULL"
+
+        bind.execute(
+            sa.text(
+                f"""
+                INSERT INTO industry_profiles (company_id, province, business_description, created_at, updated_at)
+                SELECT id, {province_expr}, {business_description_expr}, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+                FROM company
+                WHERE {province_expr} IS NOT NULL OR {business_description_expr} IS NOT NULL OR {('naics_code IS NOT NULL' if has_legacy_naics_code else '0=1')}
+                """
+            )
+        )
+
+    if has_legacy_naics_code:
+        bind.execute(
+            sa.text(
+                """
+                INSERT INTO industry_naics_codes (industry_profile_id, code, position, created_at, updated_at)
+                SELECT industry_profiles.id, CAST(company.naics_code AS CHAR(6)), 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+                FROM company
+                JOIN industry_profiles ON industry_profiles.company_id = company.id
+                WHERE company.naics_code IS NOT NULL
+                """
+            )
+        )
+
+
+def downgrade() -> None:
+    op.drop_constraint("fk_industry_naics_codes_profile_id", "industry_naics_codes", type_="foreignkey")
+    op.drop_index("ix_industry_naics_codes_industry_profile_id", table_name="industry_naics_codes")
+    op.drop_table("industry_naics_codes")
+
+    op.drop_constraint("fk_industry_profiles_company_id", "industry_profiles", type_="foreignkey")
+    op.drop_index("ix_industry_profiles_company_id", table_name="industry_profiles")
+    op.drop_table("industry_profiles")

--- a/app/api/dependencies.py
+++ b/app/api/dependencies.py
@@ -8,6 +8,7 @@ from app.repositories.company_repository import CompanyRepository
 from app.repositories.company_logo_repository import CompanyLogoRepository
 from app.repositories.user_repository import UserRepository
 from app.repositories.plan_repository import PlanRepository
+from app.repositories.industry_profile_repository import IndustryProfileRepository
 from app.repositories.document_repository import DocumentRepository
 from app.repositories.legal_acknowledgment_repository import LegalAcknowledgmentRepository
 from app.services.order_service import OrderService
@@ -41,6 +42,10 @@ def get_user_repository(db: Session = Depends(get_db)) -> UserRepository:
 
 def get_plan_repository(db: Session = Depends(get_db)) -> PlanRepository:
     return PlanRepository(db)
+
+
+def get_industry_profile_repository(db: Session = Depends(get_db)) -> IndustryProfileRepository:
+    return IndustryProfileRepository(db)
 
 
 def get_document_repository(db: Session = Depends(get_db)) -> DocumentRepository:

--- a/app/api/v1/endpoints/orders.py
+++ b/app/api/v1/endpoints/orders.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from decimal import Decimal
+from typing import Iterable
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile, status
 from sqlalchemy.orm import Session
@@ -10,6 +11,7 @@ from app.api.dependencies import (
     get_company_logo_repository,
     get_user_repository,
     get_plan_repository,
+    get_industry_profile_repository,
     get_file_storage_service,
     get_db,
 )
@@ -30,6 +32,7 @@ from app.repositories.company_repository import CompanyRepository
 from app.repositories.company_logo_repository import CompanyLogoRepository
 from app.repositories.user_repository import UserRepository
 from app.repositories.plan_repository import PlanRepository
+from app.repositories.industry_profile_repository import IndustryProfileRepository
 from app.models.company import Company
 from app.models.user import User, UserRole
 
@@ -37,6 +40,43 @@ router = APIRouter()
 
 ALLOWED_LOGO_EXTENSIONS = {".png", ".jpg", ".jpeg", ".svg"}
 MAX_LOGO_SIZE_MB = 5
+
+
+def parse_naics_codes_input(naics_codes: list[str] | None, naics_code: str | None) -> list[str]:
+    parsed_codes: list[str] = []
+
+    for raw_entry in naics_codes or []:
+        split_candidates: Iterable[str] = raw_entry.split(",") if "," in raw_entry else [raw_entry]
+        for candidate in split_candidates:
+            normalized = candidate.strip()
+            if normalized:
+                parsed_codes.append(normalized)
+
+    if naics_code and naics_code.strip():
+        parsed_codes.append(naics_code.strip())
+
+    deduplicated_codes: list[str] = []
+    seen_codes: set[str] = set()
+    for code in parsed_codes:
+        if code not in seen_codes:
+            seen_codes.add(code)
+            deduplicated_codes.append(code)
+
+    return deduplicated_codes
+
+
+def build_company_details_response(company: Company) -> CompanyDetailsResponse:
+    profile = company.industry_profile
+    naics_codes = [entry.code for entry in profile.naics_codes] if profile else []
+
+    return CompanyDetailsResponse(
+        id=company.id,
+        name=company.name,
+        logo_id=company.logo_id,
+        province=profile.province if profile else None,
+        business_description=profile.business_description if profile else None,
+        naics_codes=naics_codes,
+    )
 
 
 @router.post(
@@ -104,11 +144,14 @@ async def update_company_details(
     order_id: int,
     company_name: str = Form(..., min_length=1),
     province: str = Form(..., min_length=2, max_length=50),
-    naics_codes: str = Form(..., description="Comma-separated NAICS codes"),
+    naics_codes: list[str] | None = Form(None, description="NAICS code list"),
+    naics_code: str | None = Form(None, description="Deprecated single NAICS code"),
+    business_description: str | None = Form(None),
     logo: UploadFile | None = File(None),
     order_service: OrderService = Depends(get_order_service),
     company_repo: CompanyRepository = Depends(get_company_repository),
     company_logo_repo: CompanyLogoRepository = Depends(get_company_logo_repository),
+    industry_profile_repo: IndustryProfileRepository = Depends(get_industry_profile_repository),
     file_storage: FileStorageService = Depends(get_file_storage_service),
     db: Session = Depends(get_db),
 ) -> OrderSummaryResponse:
@@ -120,7 +163,7 @@ async def update_company_details(
             detail=f"Order {order_id} not found"
         )
     
-    naics_list = [code.strip() for code in naics_codes.split(",") if code.strip()]
+    naics_list = parse_naics_codes_input(naics_codes, naics_code)
     if not naics_list:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -133,6 +176,13 @@ async def update_company_details(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=f"Invalid NAICS code: {code}. Must be exactly 6 digits"
             )
+
+    industry_profile_repo.upsert_profile_and_codes(
+        company_id=order.company.id,
+        province=province,
+        naics_codes=naics_list,
+        business_description=business_description,
+    )
     
     company = order.company
     company.name = company_name
@@ -170,11 +220,7 @@ async def update_company_details(
     
     company_details = None
     if order.company:
-        company_details = CompanyDetailsResponse(
-            id=order.company.id,
-            name=order.company.name,
-            logo_id=order.company.logo_id,
-        )
+        company_details = build_company_details_response(order.company)
     
     return OrderSummaryResponse(
         order_id=order.id,
@@ -212,11 +258,7 @@ def get_order_summary(
     
     company_details = None
     if order.company:
-        company_details = CompanyDetailsResponse(
-            id=order.company.id,
-            name=order.company.name,
-            logo_id=order.company.logo_id,
-        )
+        company_details = build_company_details_response(order.company)
     
     return OrderSummaryResponse(
         order_id=order.id,

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -15,6 +15,8 @@ from .company_logo import CompanyLogo
 from .email_log import EmailLog, EmailStatus
 from .system_log import SystemLog, LogLevel
 from .legal_acknowledgment import LegalAcknowledgement
+from .industry_profile import IndustryProfile
+from .industry_naics_code import IndustryNAICSCode
 from .naics_code import NAICSCode
 from .naics_user_content import NAICSUserContent
 from .order_status import OrderStatus, OrderStatusEnum, PaymentStatus
@@ -35,6 +37,8 @@ __all__ = [
     "SystemLog", 
     "LogLevel",
     "LegalAcknowledgement",
+    "IndustryProfile",
+    "IndustryNAICSCode",
     "NAICSCode",
     "NAICSUserContent",
     "OrderStatus", 

--- a/app/models/company.py
+++ b/app/models/company.py
@@ -13,6 +13,7 @@ class Company(Base):
 
     users = relationship("User", back_populates="company")
     orders = relationship("Order", back_populates="company")
+    industry_profile = relationship("IndustryProfile", back_populates="company", uselist=False)
     logo = relationship(
         "CompanyLogo", 
         foreign_keys=[logo_id],

--- a/app/models/industry_naics_code.py
+++ b/app/models/industry_naics_code.py
@@ -1,0 +1,22 @@
+from datetime import datetime, timezone
+
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, UniqueConstraint
+from sqlalchemy.orm import relationship
+
+from app.database import Base
+
+
+class IndustryNAICSCode(Base):
+    __tablename__ = "industry_naics_codes"
+    __table_args__ = (
+        UniqueConstraint("industry_profile_id", "code", name="uq_industry_naics_profile_code"),
+    )
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    industry_profile_id = Column(Integer, ForeignKey("industry_profiles.id", ondelete="CASCADE", onupdate="CASCADE"), nullable=False, index=True)
+    code = Column(String(6), nullable=False)
+    position = Column(Integer, nullable=False)
+    created_at = Column(DateTime, nullable=False, default=datetime.now(timezone.utc))
+    updated_at = Column(DateTime, nullable=False, default=datetime.now(timezone.utc), onupdate=datetime.now(timezone.utc))
+
+    industry_profile = relationship("IndustryProfile", back_populates="naics_codes")

--- a/app/models/industry_profile.py
+++ b/app/models/industry_profile.py
@@ -1,0 +1,25 @@
+from datetime import datetime, timezone
+
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy.orm import relationship
+
+from app.database import Base
+
+
+class IndustryProfile(Base):
+    __tablename__ = "industry_profiles"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    company_id = Column(Integer, ForeignKey("company.id", ondelete="CASCADE", onupdate="CASCADE"), nullable=False, unique=True, index=True)
+    province = Column(String(50), nullable=True)
+    business_description = Column(Text, nullable=True)
+    created_at = Column(DateTime, nullable=False, default=datetime.now(timezone.utc))
+    updated_at = Column(DateTime, nullable=False, default=datetime.now(timezone.utc), onupdate=datetime.now(timezone.utc))
+
+    company = relationship("Company", back_populates="industry_profile")
+    naics_codes = relationship(
+        "IndustryNAICSCode",
+        back_populates="industry_profile",
+        cascade="all, delete-orphan",
+        order_by="IndustryNAICSCode.position",
+    )

--- a/app/repositories/__init__.py
+++ b/app/repositories/__init__.py
@@ -7,6 +7,7 @@ from app.repositories.plan_repository import PlanRepository
 from app.repositories.order_status_repository import OrderStatusRepository
 from app.repositories.email_log_repository import EmailLogRepository
 from app.repositories.company_logo_repository import CompanyLogoRepository
+from app.repositories.industry_profile_repository import IndustryProfileRepository
 
 __all__ = [
     "BaseRepository",
@@ -18,4 +19,5 @@ __all__ = [
     "OrderStatusRepository",
     "EmailLogRepository",
     "CompanyLogoRepository",
+    "IndustryProfileRepository",
 ]

--- a/app/repositories/industry_profile_repository.py
+++ b/app/repositories/industry_profile_repository.py
@@ -1,0 +1,67 @@
+from sqlalchemy.orm import Session, joinedload
+
+from app.models.industry_naics_code import IndustryNAICSCode
+from app.models.industry_profile import IndustryProfile
+
+
+class IndustryProfileRepository:
+    def __init__(self, db: Session):
+        self.db = db
+
+    def get_by_company_id_with_codes(self, company_id: int) -> IndustryProfile | None:
+        if not company_id:
+            raise ValueError("company_id is required")
+
+        return (
+            self.db.query(IndustryProfile)
+            .options(joinedload(IndustryProfile.naics_codes))
+            .filter(IndustryProfile.company_id == company_id)
+            .first()
+        )
+
+    def upsert_profile_and_codes(
+        self,
+        company_id: int,
+        province: str,
+        naics_codes: list[str],
+        business_description: str | None = None,
+    ) -> IndustryProfile:
+        if not company_id:
+            raise ValueError("company_id is required")
+
+        if not province:
+            raise ValueError("province is required")
+
+        if not naics_codes:
+            raise ValueError("naics_codes is required")
+
+        industry_profile = self.get_by_company_id_with_codes(company_id)
+        if not industry_profile:
+            industry_profile = IndustryProfile(company_id=company_id)
+            self.db.add(industry_profile)
+            self.db.flush()
+
+        industry_profile.province = province
+        industry_profile.business_description = business_description
+
+        (
+            self.db.query(IndustryNAICSCode)
+            .filter(IndustryNAICSCode.industry_profile_id == industry_profile.id)
+            .delete(synchronize_session=False)
+        )
+
+        for position, code in enumerate(naics_codes, start=1):
+            self.db.add(
+                IndustryNAICSCode(
+                    industry_profile_id=industry_profile.id,
+                    code=code,
+                    position=position,
+                )
+            )
+
+        self.db.commit()
+        self.db.refresh(industry_profile)
+        refreshed_profile = self.get_by_company_id_with_codes(company_id)
+        if not refreshed_profile:
+            raise ValueError("Failed to load industry profile after update")
+        return refreshed_profile

--- a/app/repositories/order_repository.py
+++ b/app/repositories/order_repository.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 from sqlalchemy.orm import Session, joinedload
 
+from app.models.company import Company
+from app.models.industry_profile import IndustryProfile
 from app.models.order import Order
 from app.models.order_status import OrderStatusEnum, PaymentStatus
 from app.repositories.base_repository import BaseRepository
@@ -18,7 +20,9 @@ class OrderRepository(BaseRepository[Order]):
             self.db.query(Order)
             .options(
                 joinedload(Order.user),
-                joinedload(Order.company),
+                joinedload(Order.company)
+                .joinedload(Company.industry_profile)
+                .joinedload(IndustryProfile.naics_codes),
                 joinedload(Order.plan),
                 joinedload(Order.order_status),
                 joinedload(Order.documents)

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -15,7 +15,7 @@ from .legal import (
     LegalAcknowledgmentRequest,
     LegalAcknowledgmentResponse,
 )
-from .responses import ErrorResponse, ErrorDetail, SuccessResponse, ErrorCode
+from .responses import ErrorResponse, SuccessResponse, ErrorCode
 from .email import OrderConfirmationContext, DocumentDeliveryContext
 
 __all__ = [
@@ -37,7 +37,6 @@ __all__ = [
 	"LegalAcknowledgmentRequest",
 	"LegalAcknowledgmentResponse",
 	"ErrorResponse",
-	"ErrorDetail",
 	"SuccessResponse",
 	"ErrorCode",
 	"OrderConfirmationContext",

--- a/app/schemas/order.py
+++ b/app/schemas/order.py
@@ -58,6 +58,9 @@ class CompanyDetailsResponse(BaseModel):
     id: int = Field(..., example=42)
     name: str = Field(..., example="Acme Safety Inc.")
     logo_id: int | None = Field(None, example=1)
+    province: str | None = Field(None, example="ON")
+    business_description: str | None = Field(None, example="Industrial painting and coating services")
+    naics_codes: list[str] = Field(default_factory=list, example=["123456", "234567"])
 
 
 class OrderSummaryResponse(BaseModel):

--- a/tests/api/test_orders.py
+++ b/tests/api/test_orders.py
@@ -145,7 +145,7 @@ def test_update_company_details_success_without_logo(client, sample_order):
     form_data = {
         "company_name": "Updated Company",
         "province": "ON",
-        "naics_codes": "123456,234567",
+        "naics_codes": ["123456", "234567", "123456"],
     }
     response = client.patch(
         f"/api/v1/orders/{sample_order.id}/company-details",
@@ -155,13 +155,15 @@ def test_update_company_details_success_without_logo(client, sample_order):
     data = response.json()
     assert data["order_id"] == sample_order.id
     assert data["company"]["name"] == "Updated Company"
+    assert data["company"]["province"] == "ON"
+    assert data["company"]["naics_codes"] == ["123456", "234567"]
 
 
 def test_update_company_details_success_with_logo(client, sample_order):
     form_data = {
         "company_name": "Company With Logo",
         "province": "ON",
-        "naics_codes": "123456",
+        "naics_codes": ["123456"],
     }
     logo_content = b"fake image content"
     files = {
@@ -176,6 +178,23 @@ def test_update_company_details_success_with_logo(client, sample_order):
     data = response.json()
     assert data["company"]["name"] == "Company With Logo"
     assert data["company"]["logo_id"] is not None
+    assert data["company"]["naics_codes"] == ["123456"]
+
+
+def test_update_company_details_supports_legacy_naics_code(client, sample_order):
+    form_data = {
+        "company_name": "Legacy Company",
+        "province": "ON",
+        "naics_code": "345678",
+    }
+    response = client.patch(
+        f"/api/v1/orders/{sample_order.id}/company-details",
+        data=form_data,
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["company"]["name"] == "Legacy Company"
+    assert data["company"]["naics_codes"] == ["345678"]
 
 
 def test_update_company_details_order_not_found(client):


### PR DESCRIPTION
Closes #27 Industry/NAICS Capture Endpoint: Accept Multiple NAICS Codes + DB Model/Migration (Optional Description)
## What Changed

### Updated NAICS capture as requested
- Changed the Industry/NAICS capture endpoint to support multiple NAICS codes.
- New input: `naics_codes: string[]`.
- Legacy input is still supported: `naics_code: string` (automatically converted to a one-item list).
- Added optional `business_description` without breaking existing clients.

### Added normalized storage + migration
- Implemented the recommended table structure for multiple NAICS codes.
- Added `industry_naics_codes` with: `id`, `industry_profile_id`, `code`, `position`, and timestamps.
- Added a unique constraint on `(industry_profile_id, code)` to prevent duplicates per profile.
- Added migration logic to move legacy single NAICS values into the new structure (when present).

### Response now matches new contract
- Updated the response payload to always return `naics_codes` as an ordered list.
- Ensures consistent output for both new and legacy request formats.

## Technical Details

**Key Implementation Notes:**
- NAICS codes are validated (6-digit numeric), deduplicated, and saved in order using `position`.
- The endpoint now uses one normalized persistence path for both `naics_codes` and legacy `naics_code`.

**Testing:**
- Added/updated API tests for multi-code input, deduplication behavior, and legacy single-code compatibility.
- Ran `pytest tests/api/test_orders.py -q` and confirmed pass (`8 passed`).
