### PR TITLE
Create province specific jurisdiction prompt packs for sjp generation

### DIFF
--- a/app/config/jurisdiction_packs/ab.yaml
+++ b/app/config/jurisdiction_packs/ab.yaml
@@ -1,0 +1,25 @@
+province_code: "AB"
+province_name: "Alberta"
+legislation_name: "Occupational Health and Safety Act, S.A. 2017, c. O-2.1"
+regulatory_body: "Alberta Occupational Health and Safety (Alberta OHS), Ministry of Jobs, Economy and Trade"
+key_regulations:
+  - "Occupational Health and Safety Code, Alta. Reg. 87/2009"
+  - "Occupational Health and Safety Regulation, Alta. Reg. 62/2003"
+  - "Part 2 — Hazard Assessment, Elimination and Control (OHS Code)"
+  - "Part 6 — Cranes, Hoists and Lifting Devices (OHS Code)"
+  - "Part 40 — Hydrogen Sulphide (OHS Code)"
+terminology_notes: >
+  In Alberta, the OHS Act establishes duties for employers, supervisors, workers, prime
+  contractors, and owners. The OHS Code contains detailed technical requirements. Alberta
+  requires employers to conduct formal hazard assessments and document controls. Workers
+  have the right to refuse dangerous work under Section 31 of the OHS Act. A Joint Work
+  Site Health and Safety Committee is required at worksites with 20 or more workers.
+prompt_preamble: >
+  The following Safe Job Procedure is intended to reflect workplace safety requirements
+  aligned with Alberta's Occupational Health and Safety Act, S.A. 2017, c. O-2.1, and
+  the Occupational Health and Safety Code (Alta. Reg. 87/2009), as administered by
+  Alberta Occupational Health and Safety under the Ministry of Jobs, Economy and Trade.
+  This content is intended to support safe work practices and does not constitute legal
+  advice. Employers should consult the current legislation and a qualified OHS
+  professional to ensure full compliance.
+

--- a/app/config/jurisdiction_packs/bc.yaml
+++ b/app/config/jurisdiction_packs/bc.yaml
@@ -1,0 +1,25 @@
+province_code: "BC"
+province_name: "British Columbia"
+legislation_name: "Workers Compensation Act, R.S.B.C. 2019, c. 1"
+regulatory_body: "WorkSafeBC (Workers' Compensation Board of British Columbia)"
+key_regulations:
+  - "Occupational Health and Safety Regulation (OHSR), B.C. Reg. 296/97"
+  - "Part 3 — Rights and Responsibilities (OHS Regulation)"
+  - "Part 4 — General Conditions (OHS Regulation)"
+  - "Part 20 — Construction, Excavation and Demolition (OHS Regulation)"
+  - "Part 9 — Confined Spaces (OHS Regulation)"
+terminology_notes: >
+  In British Columbia, occupational health and safety is administered by WorkSafeBC,
+  which combines workers' compensation and OHS regulatory functions. The primary OHS
+  instrument is the OHS Regulation made under the Workers Compensation Act. Employers
+  must establish and maintain a written OHS program. The term 'prime contractor' is used
+  on multi-employer worksites. Workers have the right to refuse unsafe work under
+  Section 3.12 of the OHS Regulation.
+prompt_preamble: >
+  The following Safe Job Procedure is intended to reflect workplace safety requirements
+  aligned with British Columbia's Workers Compensation Act, R.S.B.C. 2019, c. 1, and
+  the Occupational Health and Safety Regulation (B.C. Reg. 296/97), as administered by
+  WorkSafeBC. This content is intended to support safe work practices and does not
+  constitute legal advice. Employers should consult the current legislation and a
+  qualified OHS professional to ensure full compliance.
+

--- a/app/config/jurisdiction_packs/generic.yaml
+++ b/app/config/jurisdiction_packs/generic.yaml
@@ -1,0 +1,28 @@
+province_code: "CA"
+province_name: "Canada (Generic)"
+legislation_name: "Canada Labour Code, R.S.C. 1985, c. L-2 (Part II — Occupational Health and Safety)"
+regulatory_body: "Employment and Social Development Canada (ESDC) — Labour Program"
+key_regulations:
+  - "Canada Occupational Health and Safety Regulations, SOR/86-304"
+  - "Part II of the Canada Labour Code — Occupational Health and Safety"
+  - "Hazardous Occurrence Investigation, Recording and Reporting Regulations, SOR/86-294"
+  - "Canada Occupational Health and Safety Regulations — Part X (Hazardous Substances)"
+terminology_notes: >
+  This is a generic Canadian OHS preamble used when no province-specific pack is
+  available. Federal OHS legislation (Part II of the Canada Labour Code) applies to
+  federally regulated workplaces including banks, airlines, telecommunications, and
+  interprovincial transportation. Most workplaces fall under provincial jurisdiction.
+  Employers are strongly encouraged to consult the specific provincial or territorial
+  legislation applicable to their workplace. Workers have the right to refuse dangerous
+  work under Section 128 of the Canada Labour Code.
+prompt_preamble: >
+  The following Safe Job Procedure is intended to reflect general workplace safety
+  requirements aligned with Canadian occupational health and safety best practices and,
+  where applicable, Part II of the Canada Labour Code, R.S.C. 1985, c. L-2, as
+  administered by Employment and Social Development Canada. Note: most Canadian workplaces
+  fall under provincial or territorial OHS jurisdiction — this procedure should be
+  reviewed against the legislation applicable to your specific province or territory.
+  This content is intended to support safe work practices and does not constitute legal
+  advice. Employers should consult the current legislation and a qualified OHS
+  professional to ensure full compliance.
+

--- a/app/config/jurisdiction_packs/on.yaml
+++ b/app/config/jurisdiction_packs/on.yaml
@@ -1,0 +1,25 @@
+province_code: "ON"
+province_name: "Ontario"
+legislation_name: "Occupational Health and Safety Act (OHSA), R.S.O. 1990, c. O.1"
+regulatory_body: "Ontario Ministry of Labour, Immigration, Training and Skills Development"
+key_regulations:
+  - "O. Reg. 213/91 — Construction Projects"
+  - "O. Reg. 851 — Industrial Establishments"
+  - "O. Reg. 632/05 — Confined Spaces"
+  - "O. Reg. 490/09 — Designated Substances"
+  - "O. Reg. 297/13 — Occupational Health and Safety Awareness and Training"
+terminology_notes: >
+  In Ontario, the employer's primary duty-holder is referred to as the 'constructor' on
+  construction projects and 'employer' in industrial settings. Joint Health and Safety
+  Committees (JHSCs) are required for workplaces with 20 or more workers. Workers have
+  the right to refuse unsafe work under Section 43 of the OHSA.
+prompt_preamble: >
+  The following Safe Job Procedure is intended to reflect workplace safety requirements
+  aligned with Ontario's Occupational Health and Safety Act (OHSA), R.S.O. 1990, c. O.1,
+  and applicable regulations including O. Reg. 213/91 (Construction Projects) and
+  O. Reg. 851 (Industrial Establishments), as administered by the Ontario Ministry of
+  Labour, Immigration, Training and Skills Development. This content is intended to
+  support safe work practices and does not constitute legal advice. Employers should
+  consult the current legislation and a qualified OHS professional to ensure full
+  compliance.
+

--- a/app/config/jurisdiction_packs/qc.yaml
+++ b/app/config/jurisdiction_packs/qc.yaml
@@ -1,0 +1,27 @@
+province_code: "QC"
+province_name: "Quebec"
+legislation_name: "Act Respecting Occupational Health and Safety (LSST), CQLR c. S-2.1"
+regulatory_body: "Commission des normes, de l'équité, de la santé et de la sécurité du travail (CNESST)"
+key_regulations:
+  - "Regulation Respecting Occupational Health and Safety, CQLR c. S-2.1, r. 13"
+  - "Safety Code for the Construction Industry, CQLR c. S-2.1, r. 4"
+  - "Regulation Respecting Sanitary Conditions in Industrial Establishments, CQLR c. S-2.1, r. 18"
+  - "Act Respecting Industrial Accidents and Occupational Diseases (LATMP), CQLR c. A-3.001"
+  - "An Act to Modernize the Occupational Health and Safety Regime, S.Q. 2021, c. 27"
+terminology_notes: >
+  In Quebec, OHS is governed by the LSST and administered by the CNESST, which also
+  handles workers' compensation. The 2021 modernization act (Bill 59) expanded joint OHS
+  committee requirements and introduced new prevention programs. Quebec uses the term
+  'programme de prévention' for employer OHS programs. Workers have the right to refuse
+  dangerous work under Section 12 of the LSST. Joint health and safety committees
+  ('comité de santé et de sécurité') are required in establishments with 20 or more
+  workers in priority sectors.
+prompt_preamble: >
+  The following Safe Job Procedure is intended to reflect workplace safety requirements
+  aligned with Quebec's Act Respecting Occupational Health and Safety (LSST, CQLR c.
+  S-2.1) and the Regulation Respecting Occupational Health and Safety (CQLR c. S-2.1,
+  r. 13), as administered by the Commission des normes, de l'équité, de la santé et de
+  la sécurité du travail (CNESST). This content is intended to support safe work
+  practices and does not constitute legal advice. Employers should consult the current
+  legislation and a qualified OHS professional to ensure full compliance.
+

--- a/app/schemas/jurisdiction.py
+++ b/app/schemas/jurisdiction.py
@@ -1,0 +1,13 @@
+from pydantic import BaseModel, Field
+
+
+class JurisdictionPromptPack(BaseModel):
+    province_code: str = Field(..., min_length=2, max_length=3)
+    province_name: str = Field(..., min_length=1)
+    legislation_name: str = Field(..., min_length=1)
+    regulatory_body: str = Field(..., min_length=1)
+    key_regulations: list[str] = Field(..., min_length=1)
+    terminology_notes: str = Field(..., min_length=1)
+    prompt_preamble: str = Field(..., min_length=1)
+    is_generic: bool = Field(default=False)
+

--- a/app/services/exceptions.py
+++ b/app/services/exceptions.py
@@ -67,3 +67,12 @@ class FileNotFoundServiceException(FileStorageServiceException):
 
 class DocumentGenerationServiceException(ServiceException):
     pass
+
+
+class JurisdictionServiceException(ServiceException):
+    pass
+
+
+class JurisdictionPackLoadError(JurisdictionServiceException):
+    pass
+

--- a/app/services/jurisdiction_service.py
+++ b/app/services/jurisdiction_service.py
@@ -1,0 +1,78 @@
+import logging
+from pathlib import Path
+
+import yaml
+from pydantic import ValidationError
+
+from app.schemas.jurisdiction import JurisdictionPromptPack
+from app.services.exceptions import JurisdictionPackLoadError
+from app.services.validation_service import CANADIAN_PROVINCES
+
+logger = logging.getLogger(__name__)
+
+_GENERIC_PACK_FILENAME = "generic.yaml"
+_DEFAULT_PACKS_DIR = Path(__file__).parent.parent / "config" / "jurisdiction_packs"
+
+
+class JurisdictionService:
+    def __init__(self, packs_dir: Path | None = _DEFAULT_PACKS_DIR):
+        if not packs_dir:
+            raise ValueError("packs_dir is required")
+
+        self.packs_dir = packs_dir
+
+    def get_pack(self, province_code: str | None) -> JurisdictionPromptPack:
+        if not province_code:
+            raise ValueError("province_code is required")
+
+        normalized_code = province_code.strip().upper()
+
+        if normalized_code not in CANADIAN_PROVINCES:
+            from app.services.exceptions import InvalidProvinceException
+            raise InvalidProvinceException(
+                f"'{province_code}' is not a recognized Canadian province or territory code"
+            )
+
+        province_pack_path = self.packs_dir / f"{normalized_code.lower()}.yaml"
+
+        if province_pack_path.exists():
+            return self._load_pack_file(province_pack_path, is_generic=False)
+
+        logger.warning(
+            "No jurisdiction pack found for province '%s', falling back to generic pack",
+            normalized_code,
+        )
+
+        generic_pack_path = self.packs_dir / _GENERIC_PACK_FILENAME
+
+        if not generic_pack_path.exists():
+            raise JurisdictionPackLoadError(
+                f"No pack found for province '{normalized_code}' and generic fallback pack is missing at {generic_pack_path}"
+            )
+
+        return self._load_pack_file(generic_pack_path, is_generic=True)
+
+    def _load_pack_file(self, path: Path, is_generic: bool) -> JurisdictionPromptPack:
+        try:
+            raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except yaml.YAMLError as exc:
+            raise JurisdictionPackLoadError(
+                f"Failed to parse jurisdiction pack at {path}: {exc}"
+            ) from exc
+        except OSError as exc:
+            raise JurisdictionPackLoadError(
+                f"Failed to read jurisdiction pack at {path}: {exc}"
+            ) from exc
+
+        if not isinstance(raw, dict):
+            raise JurisdictionPackLoadError(
+                f"Jurisdiction pack at {path} must be a YAML mapping, got {type(raw).__name__}"
+            )
+
+        try:
+            return JurisdictionPromptPack(**raw, is_generic=is_generic)
+        except ValidationError as exc:
+            raise JurisdictionPackLoadError(
+                f"Jurisdiction pack at {path} failed schema validation: {exc}"
+            ) from exc
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ stripe
 python-multipart
 python-jose
 passlib
+pyyaml

--- a/tests/unit/services/test_jurisdiction_service.py
+++ b/tests/unit/services/test_jurisdiction_service.py
@@ -1,0 +1,261 @@
+import logging
+
+import pytest
+
+from app.schemas.jurisdiction import JurisdictionPromptPack
+from app.services.exceptions import InvalidProvinceException, JurisdictionPackLoadError
+from app.services.jurisdiction_service import JurisdictionService
+
+_VALID_ON_PACK = """\
+province_code: "ON"
+province_name: "Ontario"
+legislation_name: "Occupational Health and Safety Act (OHSA), R.S.O. 1990, c. O.1"
+regulatory_body: "Ontario Ministry of Labour, Immigration, Training and Skills Development"
+key_regulations:
+  - "O. Reg. 213/91 — Construction Projects"
+  - "O. Reg. 851 — Industrial Establishments"
+terminology_notes: "Workers have the right to refuse unsafe work under Section 43 of the OHSA."
+prompt_preamble: "The following Safe Job Procedure is intended to reflect Ontario OHSA requirements."
+"""
+
+_VALID_GENERIC_PACK = """\
+province_code: "CA"
+province_name: "Canada (Generic)"
+legislation_name: "Canada Labour Code, R.S.C. 1985, c. L-2"
+regulatory_body: "Employment and Social Development Canada (ESDC)"
+key_regulations:
+  - "Canada Occupational Health and Safety Regulations, SOR/86-304"
+terminology_notes: "Generic Canadian OHS preamble for unsupported provinces."
+prompt_preamble: "The following Safe Job Procedure is aligned with general Canadian OHS best practices."
+"""
+
+
+@pytest.fixture
+def packs_dir(tmp_path):
+    (tmp_path / "on.yaml").write_text(_VALID_ON_PACK, encoding="utf-8")
+    (tmp_path / "generic.yaml").write_text(_VALID_GENERIC_PACK, encoding="utf-8")
+    return tmp_path
+
+
+@pytest.fixture
+def service(packs_dir):
+    return JurisdictionService(packs_dir=packs_dir)
+
+
+class TestJurisdictionServiceHappyPath:
+    def test_get_pack_returns_jurisdiction_prompt_pack_instance(self, service):
+        pack = service.get_pack("ON")
+        assert isinstance(pack, JurisdictionPromptPack)
+
+    def test_get_pack_province_code_matches_yaml(self, service):
+        pack = service.get_pack("ON")
+        assert pack.province_code == "ON"
+
+    def test_get_pack_province_name_matches_yaml(self, service):
+        pack = service.get_pack("ON")
+        assert pack.province_name == "Ontario"
+
+    def test_get_pack_legislation_name_matches_yaml(self, service):
+        pack = service.get_pack("ON")
+        assert "OHSA" in pack.legislation_name
+
+    def test_get_pack_regulatory_body_matches_yaml(self, service):
+        pack = service.get_pack("ON")
+        assert "Ontario Ministry" in pack.regulatory_body
+
+    def test_get_pack_key_regulations_is_populated_list(self, service):
+        pack = service.get_pack("ON")
+        assert isinstance(pack.key_regulations, list)
+        assert len(pack.key_regulations) == 2
+
+    def test_get_pack_terminology_notes_is_populated(self, service):
+        pack = service.get_pack("ON")
+        assert len(pack.terminology_notes) > 0
+
+    def test_get_pack_prompt_preamble_is_populated(self, service):
+        pack = service.get_pack("ON")
+        assert len(pack.prompt_preamble) > 0
+
+    def test_get_pack_is_generic_false_for_known_province_with_pack(self, service):
+        pack = service.get_pack("ON")
+        assert pack.is_generic is False
+
+
+class TestJurisdictionServiceCaseInsensitivity:
+    def test_lowercase_province_code_resolves(self, service):
+        pack = service.get_pack("on")
+        assert pack.province_code == "ON"
+
+    def test_mixed_case_province_code_resolves(self, service):
+        pack = service.get_pack("On")
+        assert pack.province_code == "ON"
+
+    def test_uppercase_province_code_resolves(self, service):
+        pack = service.get_pack("ON")
+        assert pack.province_code == "ON"
+
+    def test_province_code_with_surrounding_whitespace_resolves(self, service):
+        pack = service.get_pack("  ON  ")
+        assert pack.province_code == "ON"
+
+
+class TestJurisdictionServiceFallback:
+    def test_valid_province_without_dedicated_pack_returns_generic(self, service):
+        pack = service.get_pack("MB")
+        assert isinstance(pack, JurisdictionPromptPack)
+
+    def test_fallback_pack_is_generic_true(self, service):
+        pack = service.get_pack("MB")
+        assert pack.is_generic is True
+
+    def test_fallback_pack_has_generic_province_code(self, service):
+        pack = service.get_pack("SK")
+        assert pack.province_code == "CA"
+
+    def test_fallback_pack_prompt_preamble_is_populated(self, service):
+        pack = service.get_pack("NT")
+        assert len(pack.prompt_preamble) > 0
+
+    def test_fallback_applies_for_all_provinces_without_packs(self, packs_dir):
+        service = JurisdictionService(packs_dir=packs_dir)
+        provinces_without_packs = ["MB", "NB", "NL", "NS", "NT", "NU", "PE", "SK", "YT"]
+        for province in provinces_without_packs:
+            pack = service.get_pack(province)
+            assert pack.is_generic is True, f"Expected is_generic=True for {province}"
+
+    def test_fallback_emits_warning_log(self, service, caplog):
+        with caplog.at_level(logging.WARNING, logger="app.services.jurisdiction_service"):
+            service.get_pack("MB")
+        assert "MB" in caplog.text
+        assert any(r.levelname == "WARNING" for r in caplog.records)
+
+    def test_no_warning_emitted_for_province_with_dedicated_pack(self, service, caplog):
+        with caplog.at_level(logging.WARNING, logger="app.services.jurisdiction_service"):
+            service.get_pack("ON")
+        assert not any(r.levelname == "WARNING" for r in caplog.records)
+
+
+class TestJurisdictionServiceRealPackFiles:
+    def test_all_four_required_province_packs_load_successfully(self):
+        service = JurisdictionService()
+        for province_code in ["ON", "BC", "AB", "QC"]:
+            pack = service.get_pack(province_code)
+            assert isinstance(pack, JurisdictionPromptPack), f"Failed to load pack for {province_code}"
+            assert pack.is_generic is False, f"Expected real pack for {province_code}"
+
+    def test_real_on_pack_has_correct_legislation(self):
+        service = JurisdictionService()
+        pack = service.get_pack("ON")
+        assert "OHSA" in pack.legislation_name
+        assert "Ontario" in pack.regulatory_body
+
+    def test_real_bc_pack_has_correct_legislation(self):
+        service = JurisdictionService()
+        pack = service.get_pack("BC")
+        assert "Workers Compensation Act" in pack.legislation_name
+        assert "WorkSafeBC" in pack.regulatory_body
+
+    def test_real_ab_pack_has_correct_legislation(self):
+        service = JurisdictionService()
+        pack = service.get_pack("AB")
+        assert "Occupational Health and Safety Act" in pack.legislation_name
+        assert "Alberta" in pack.regulatory_body
+
+    def test_real_qc_pack_has_correct_legislation(self):
+        service = JurisdictionService()
+        pack = service.get_pack("QC")
+        assert "LSST" in pack.legislation_name or "Occupational Health and Safety" in pack.legislation_name
+        assert "CNESST" in pack.regulatory_body
+
+    def test_all_real_packs_have_non_empty_prompt_preamble(self):
+        service = JurisdictionService()
+        for province_code in ["ON", "BC", "AB", "QC"]:
+            pack = service.get_pack(province_code)
+            assert len(pack.prompt_preamble.strip()) > 0, f"Empty preamble for {province_code}"
+
+    def test_all_real_packs_have_at_least_one_key_regulation(self):
+        service = JurisdictionService()
+        for province_code in ["ON", "BC", "AB", "QC"]:
+            pack = service.get_pack(province_code)
+            assert len(pack.key_regulations) >= 1, f"No key regulations for {province_code}"
+
+    def test_all_real_packs_preamble_does_not_claim_legal_compliance(self):
+        service = JurisdictionService()
+        forbidden_phrases = ["ensures compliance", "guarantees compliance", "legally compliant"]
+        for province_code in ["ON", "BC", "AB", "QC"]:
+            pack = service.get_pack(province_code)
+            for phrase in forbidden_phrases:
+                assert phrase.lower() not in pack.prompt_preamble.lower(), (
+                    f"Forbidden phrase '{phrase}' found in {province_code} preamble"
+                )
+
+    def test_all_real_packs_preamble_contains_intended_to_reflect_language(self):
+        service = JurisdictionService()
+        for province_code in ["ON", "BC", "AB", "QC"]:
+            pack = service.get_pack(province_code)
+            preamble_lower = pack.prompt_preamble.lower()
+            has_safe_language = (
+                "intended to reflect" in preamble_lower
+                or "aligned with" in preamble_lower
+                or "intended to support" in preamble_lower
+            )
+            assert has_safe_language, (
+                f"Pack for {province_code} preamble is missing 'intended to reflect' / 'aligned with' language"
+            )
+
+    def test_all_real_packs_preamble_contains_no_legal_advice_disclaimer(self):
+        service = JurisdictionService()
+        for province_code in ["ON", "BC", "AB", "QC"]:
+            pack = service.get_pack(province_code)
+            assert "does not constitute legal advice" in pack.prompt_preamble.lower(), (
+                f"Pack for {province_code} is missing 'does not constitute legal advice' disclaimer"
+            )
+
+
+class TestJurisdictionServiceErrors:
+    def test_empty_province_code_raises_value_error(self, service):
+        with pytest.raises(ValueError, match="province_code is required"):
+            service.get_pack("")
+
+    def test_none_province_code_raises_value_error(self, service):
+        with pytest.raises(ValueError, match="province_code is required"):
+            service.get_pack(None)
+
+    def test_unrecognized_province_code_raises_invalid_province_exception(self, service):
+        with pytest.raises(InvalidProvinceException):
+            service.get_pack("XX")
+
+    def test_unrecognized_province_code_error_includes_bad_code(self, service):
+        with pytest.raises(InvalidProvinceException, match="ZZ"):
+            service.get_pack("ZZ")
+
+    def test_malformed_yaml_raises_jurisdiction_pack_load_error(self, packs_dir):
+        (packs_dir / "on.yaml").write_text("key: [unclosed bracket", encoding="utf-8")
+        broken_service = JurisdictionService(packs_dir=packs_dir)
+        with pytest.raises(JurisdictionPackLoadError, match="Failed to parse"):
+            broken_service.get_pack("ON")
+
+    def test_non_mapping_yaml_raises_jurisdiction_pack_load_error(self, packs_dir):
+        (packs_dir / "on.yaml").write_text("- just\n- a\n- list\n", encoding="utf-8")
+        broken_service = JurisdictionService(packs_dir=packs_dir)
+        with pytest.raises(JurisdictionPackLoadError, match="must be a YAML mapping"):
+            broken_service.get_pack("ON")
+
+    def test_schema_validation_failure_raises_jurisdiction_pack_load_error(self, packs_dir):
+        (packs_dir / "on.yaml").write_text(
+            "province_code: 'ON'\nprovince_name: 'Ontario'\n", encoding="utf-8"
+        )
+        broken_service = JurisdictionService(packs_dir=packs_dir)
+        with pytest.raises(JurisdictionPackLoadError, match="failed schema validation"):
+            broken_service.get_pack("ON")
+
+    def test_missing_generic_fallback_raises_jurisdiction_pack_load_error(self, tmp_path):
+        (tmp_path / "on.yaml").write_text(_VALID_ON_PACK, encoding="utf-8")
+        service_no_generic = JurisdictionService(packs_dir=tmp_path)
+        with pytest.raises(JurisdictionPackLoadError, match="generic fallback pack is missing"):
+            service_no_generic.get_pack("MB")
+
+    def test_none_packs_dir_raises_value_error(self):
+        with pytest.raises(ValueError, match="packs_dir is required"):
+            JurisdictionService(packs_dir=None)
+


### PR DESCRIPTION
Closes #53

## What Changed

### Configuration
- Added `app/config/jurisdiction_packs/` directory with province-specific YAML packs
  - `on.yaml` — Ontario: OHSA R.S.O. 1990 c. O.1, O. Reg. 213/91, O. Reg. 851, Ministry of Labour
  - `bc.yaml` — British Columbia: Workers Compensation Act, OHS Regulation B.C. Reg. 296/97, WorkSafeBC
  - `ab.yaml` — Alberta: OHS Act S.A. 2017, OHS Code Alta. Reg. 87/2009, Alberta OHS
  - `qc.yaml` — Quebec: LSST, Bill 59 (2021 modernization), CNESST
  - `generic.yaml` — Canada generic fallback: Canada Labour Code Part II, ESDC

### Services & Schemas
- Added `app/schemas/jurisdiction.py` — `JurisdictionPromptPack` Pydantic model
  - Fields: `province_code`, `province_name`, `legislation_name`, `regulatory_body`, `key_regulations`, `terminology_notes`, `prompt_preamble`, `is_generic`
- Added `app/services/exceptions.py` — `JurisdictionServiceException`, `JurisdictionPackLoadError`, `InvalidProvinceException`
- Added `app/services/jurisdiction_service.py` — `JurisdictionService.get_pack(province_code: str) -> JurisdictionPromptPack`
  - Loads YAML from `app/config/jurisdiction_packs/{code}.yaml`
  - Validates structure via Pydantic schema
  - Falls back to `generic.yaml` with `is_generic=True` and a `WARNING` log for unsupported provinces
  - Fails fast on empty/None code, unrecognized code, malformed YAML, missing generic fallback

## Technical Details

**Key Implementation Notes:**
- Packs are loaded from files (not hardcoded) — non-developers can update legislation names and preambles without touching code
- `prompt_preamble` is the key injection field — it gets prepended to every SJP generation prompt for the province; all preambles use "intended to reflect" / "aligned with" language and include a "does not constitute legal advice" disclaimer
- `JurisdictionService` accepts an optional `packs_dir: Path` constructor argument for testability — production code uses the bundled `app/config/jurisdiction_packs/` directory by default

**Testing:**
- 39 unit tests in `tests/unit/services/test_jurisdiction_service.py` across 5 classes: happy path, case-insensitivity, fallback behaviour, real pack file assertions, and error cases
- Real pack tests assert factually accurate legislation names and regulatory body references, absence of forbidden compliance language, and presence of required disclaimer copy
