### PR TITLE
44 add industry specific plan type for standalone sjp purchases

### DIFF
--- a/alembic/versions/7d4a9c8e1b2f_add_industry_specific_plan_seed.py
+++ b/alembic/versions/7d4a9c8e1b2f_add_industry_specific_plan_seed.py
@@ -1,0 +1,54 @@
+"""add industry specific plan seed
+
+Revision ID: 7d4a9c8e1b2f
+Revises: 41e2314c64cd
+Create Date: 2026-04-06 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "7d4a9c8e1b2f"
+down_revision: Union[str, None] = "41e2314c64cd"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+
+    bind.execute(
+        sa.text(
+            """
+            INSERT INTO plans (slug, name, description, base_price)
+            SELECT :slug, :name, :description, :base_price
+            WHERE NOT EXISTS (
+                SELECT 1 FROM plans WHERE slug = :slug
+            )
+            """
+        ),
+        {
+            "slug": "industry_specific",
+            "name": "Industry Specific",
+            "description": "Industry-specific SJP generation for existing manuals",
+            "base_price": 50.00,
+        },
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+
+    bind.execute(
+        sa.text(
+            """
+            DELETE FROM plans
+            WHERE slug = :slug
+            """
+        ),
+        {"slug": "industry_specific"},
+    )

--- a/app/models/plan.py
+++ b/app/models/plan.py
@@ -8,11 +8,13 @@ from app.database import Base
 class PlanSlug(str, Enum):
     BASIC = "basic"
     COMPREHENSIVE = "comprehensive"
+    INDUSTRY_SPECIFIC = "industry_specific"
 
 
 class PlanName(str, Enum):
     BASIC = "Basic"
     COMPREHENSIVE = "Comprehensive"
+    INDUSTRY_SPECIFIC = "Industry Specific"
 
 
 class Plan(Base):

--- a/app/services/order_service.py
+++ b/app/services/order_service.py
@@ -8,6 +8,7 @@ from app.repositories.order_status_repository import OrderStatusRepository
 from app.repositories.company_repository import CompanyRepository
 from app.repositories.user_repository import UserRepository
 from app.repositories.plan_repository import PlanRepository
+from app.models.plan import PlanSlug
 from app.services.validation_service import ValidationService
 from app.services.exceptions import (
     OrderServiceException,
@@ -279,9 +280,16 @@ class OrderService:
         plan = self.plan_repo.get_by_id_or_fail(plan_id)
         
         total = Decimal(plan.base_price)
+
+        # Standalone industry-specific purchases use only the selected plan price.
+        if plan.slug == PlanSlug.INDUSTRY_SPECIFIC.value:
+            return total
         
         if is_industry_specific:
-            industry_addon = Decimal("50.00")
-            total += industry_addon
+            industry_addon_plan = self.plan_repo.get_by_slug(PlanSlug.INDUSTRY_SPECIFIC)
+            if not industry_addon_plan:
+                raise OrderServiceException("industry_specific plan is not configured")
+
+            total += Decimal(industry_addon_plan.base_price)
         
         return total

--- a/scripts/seed_plans.py
+++ b/scripts/seed_plans.py
@@ -1,6 +1,7 @@
 import sys
 import os
 from pathlib import Path
+from decimal import Decimal
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 import pymysql
@@ -27,34 +28,48 @@ config = {
     'charset': 'utf8mb4'
 }
 
+BASIC_PLAN_PRICE = Decimal(os.getenv("BASIC_PLAN_BASE_PRICE", "99.99"))
+COMPREHENSIVE_PLAN_PRICE = Decimal(os.getenv("COMPREHENSIVE_PLAN_BASE_PRICE", "199.99"))
+INDUSTRY_SPECIFIC_PLAN_PRICE = Decimal(os.getenv("INDUSTRY_SPECIFIC_PLAN_BASE_PRICE", "50.00"))
+
 try:
     print(f"Connecting to {config['host']}:{config['port']}/{config['database']} as {config['user']}...")
     connection = pymysql.connect(**config)
     
     with connection.cursor() as cursor:
     
-        cursor.execute("SELECT COUNT(*) FROM plans")
-        count = cursor.fetchone()[0]
-        
-        if count >= 2:
-            print(f"Found {count} plans, skipping")
-            sys.exit(0)
-        
-        
-        print("Inserting plans...")
-        cursor.execute("""
-            INSERT INTO plans (slug, name, description, base_price)
-            VALUES ('basic', 'Basic', 'Basic OHS manual', 99.99)
-        """)
-        
-        cursor.execute("""
-            INSERT INTO plans (slug, name, description, base_price)
-            VALUES ('comprehensive', 'Comprehensive', 'Comprehensive OHS manual', 199.99)
-        """)
+        print("Ensuring required plans exist...")
+
+        plans_to_seed = [
+            ("basic", "Basic", "Basic OHS manual", BASIC_PLAN_PRICE),
+            ("comprehensive", "Comprehensive", "Comprehensive OHS manual", COMPREHENSIVE_PLAN_PRICE),
+            (
+                "industry_specific",
+                "Industry Specific",
+                "Industry-specific SJP generation for existing manuals",
+                INDUSTRY_SPECIFIC_PLAN_PRICE,
+            ),
+        ]
+
+        inserted = 0
+        for slug, name, description, base_price in plans_to_seed:
+            cursor.execute("SELECT id FROM plans WHERE slug = %s", (slug,))
+            existing = cursor.fetchone()
+            if existing:
+                continue
+
+            cursor.execute(
+                """
+                INSERT INTO plans (slug, name, description, base_price)
+                VALUES (%s, %s, %s, %s)
+                """,
+                (slug, name, description, str(base_price)),
+            )
+            inserted += 1
         
         connection.commit()
         
-        print("Plans inserted successfully")
+        print(f"Inserted {inserted} new plan(s)")
         
     
         cursor.execute("SELECT id, slug, name, base_price FROM plans")

--- a/tests/unit/services/test_order_service.py
+++ b/tests/unit/services/test_order_service.py
@@ -99,6 +99,26 @@ def sample_plan(plan_repo):
     )
 
 
+@pytest.fixture
+def sample_comprehensive_plan(plan_repo):
+    return plan_repo.create_plan(
+        slug=PlanSlug.COMPREHENSIVE,
+        name=PlanName.COMPREHENSIVE,
+        base_price=199.99,
+        description="Comprehensive plan",
+    )
+
+
+@pytest.fixture
+def sample_industry_specific_plan(plan_repo):
+    return plan_repo.create_plan(
+        slug=PlanSlug.INDUSTRY_SPECIFIC,
+        name=PlanName.INDUSTRY_SPECIFIC,
+        base_price=50.00,
+        description="Industry-specific SJP generation",
+    )
+
+
 class TestOrderService:
     def test_create_order(self, order_service, sample_user, sample_company, sample_plan):
         order = order_service.create_order(
@@ -365,10 +385,39 @@ class TestOrderService:
         
         assert total == Decimal("99.99")
 
-    def test_calculate_order_total_with_industry_specific(self, order_service, sample_plan):
+    def test_calculate_order_total_with_industry_specific(self, order_service, sample_plan, sample_industry_specific_plan):
         total = order_service.calculate_order_total(sample_plan.id, is_industry_specific=True)
         
         assert total == Decimal("149.99")
+
+    def test_calculate_order_total_comprehensive(self, order_service, sample_comprehensive_plan):
+        total = order_service.calculate_order_total(sample_comprehensive_plan.id)
+
+        assert total == Decimal("199.99")
+
+    def test_calculate_order_total_comprehensive_with_industry_specific(
+        self,
+        order_service,
+        sample_comprehensive_plan,
+        sample_industry_specific_plan,
+    ):
+        total = order_service.calculate_order_total(sample_comprehensive_plan.id, is_industry_specific=True)
+
+        assert total == Decimal("249.99")
+
+    def test_calculate_order_total_standalone_industry_specific(self, order_service, sample_industry_specific_plan):
+        total = order_service.calculate_order_total(sample_industry_specific_plan.id)
+
+        assert total == Decimal("50.00")
+
+    def test_calculate_order_total_standalone_industry_specific_ignores_addon_flag(
+        self,
+        order_service,
+        sample_industry_specific_plan,
+    ):
+        total = order_service.calculate_order_total(sample_industry_specific_plan.id, is_industry_specific=True)
+
+        assert total == Decimal("50.00")
 
     def test_get_orders_by_status(self, order_service, sample_user, sample_company, sample_plan):
         order = order_service.create_order(


### PR DESCRIPTION
Closes #44 

## What Changed

### Plan System
- Added `INDUSTRY_SPECIFIC` plan enum and seed support
  - Standalone product for SJP-only customers
  - Configurable pricing via env vars

### Order Pricing
- Replaced hardcoded $50 add-on with plan-driven pricing
  - Looks up industry-specific plan price from database
  - Supports both standalone and add-on purchase paths

### Database
- Added Alembic migration to backfill industry-specific plan

## Technical Details

**Key Implementation Notes:**
- `is_industry_specific` flag indicates SJP inclusion regardless of purchase path
- Standalone: plan_id = industry_specific_plan; Add-on: plan_id = base_plan + flag

**Testing:**
- Unit tests cover all pricing paths (basic/comprehensive with/without add-on, standalone)
- Verified backward compatibility with existing order flow

## Loom Video
[Recording space for demonstration]
