### PR TITLE
Admin controls

### DIFF
--- a/alembic/versions/a1b2c3d4e5f6_add_admin_users_and_approval_workflow.py
+++ b/alembic/versions/a1b2c3d4e5f6_add_admin_users_and_approval_workflow.py
@@ -1,0 +1,63 @@
+"""add admin_users table and approval workflow columns
+
+Revision ID: a1b2c3d4e5f6
+Revises: 41e2314c64cd
+Create Date: 2026-04-06
+
+"""
+from typing import Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "a1b2c3d4e5f6"
+down_revision: Union[str, None] = "41e2314c64cd"
+branch_labels: Union[str, None] = None
+depends_on: Union[str, None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "admin_users",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("email", sa.String(255), nullable=False),
+        sa.Column("full_name", sa.String(255), nullable=False),
+        sa.Column("role", sa.String(50), nullable=False, server_default="manager"),
+        sa.Column("password_hash", sa.String(255), nullable=False),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default="1"),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column("last_login", sa.DateTime(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("email"),
+    )
+
+    op.add_column(
+        "plans",
+        sa.Column("requires_approval", sa.Boolean(), nullable=False, server_default="0"),
+    )
+
+    op.add_column(
+        "orders",
+        sa.Column("reviewed_by_admin_id", sa.Integer(), nullable=True),
+    )
+    op.add_column(
+        "orders",
+        sa.Column("reviewed_at", sa.DateTime(), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_orders_reviewed_by_admin",
+        "orders",
+        "admin_users",
+        ["reviewed_by_admin_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("fk_orders_reviewed_by_admin", "orders", type_="foreignkey")
+    op.drop_column("orders", "reviewed_at")
+    op.drop_column("orders", "reviewed_by_admin_id")
+    op.drop_column("plans", "requires_approval")
+    op.drop_table("admin_users")

--- a/app/api/dependencies.py
+++ b/app/api/dependencies.py
@@ -27,6 +27,11 @@ from app.services.email_template_renderer import EmailTemplateRenderer
 from app.services.payment_service import PaymentService
 from app.services.auth_service import AuthService
 from app.services.stripe_provider import StripePaymentProvider
+from app.services.order_fulfillment_service import OrderFulfillmentService
+from app.services.admin_order_service import AdminOrderService
+from app.services.admin_auth_service import AdminAuthService
+from app.repositories.admin_user_repository import AdminUserRepository
+from app.models.admin_user import AdminRole
 from app.config import settings
 
 
@@ -204,6 +209,74 @@ def get_authenticated_user_context(
     request.state.user_id = user_data["id"]
     request.state.user_email = user_data["email"]
     return user_data
+
+
+def get_order_fulfillment_service(
+    order_repo: OrderRepository = Depends(get_order_repository),
+    order_status_repo: OrderStatusRepository = Depends(get_order_status_repository),
+    document_repo: DocumentRepository = Depends(get_document_repository),
+    document_service: DocumentService = Depends(get_document_service),
+    email_service: EmailService = Depends(get_email_service),
+    renderer: EmailTemplateRenderer = Depends(get_email_template_renderer),
+) -> OrderFulfillmentService:
+    return OrderFulfillmentService(
+        order_repo,
+        order_status_repo,
+        document_repo,
+        document_service,
+        email_service,
+        renderer,
+    )
+
+
+def get_admin_order_service(
+    order_repo: OrderRepository = Depends(get_order_repository),
+    order_status_repo: OrderStatusRepository = Depends(get_order_status_repository),
+    fulfillment_service: OrderFulfillmentService = Depends(get_order_fulfillment_service),
+) -> AdminOrderService:
+    return AdminOrderService(order_repo, order_status_repo, fulfillment_service)
+
+
+def get_admin_user_repository(db: Session = Depends(get_db)) -> AdminUserRepository:
+    return AdminUserRepository(db)
+
+
+def get_admin_auth_service(
+    admin_user_repo: AdminUserRepository = Depends(get_admin_user_repository),
+) -> AdminAuthService:
+    return AdminAuthService(
+        admin_user_repo=admin_user_repo,
+        settings=settings,
+    )
+
+
+def get_authenticated_admin_context(
+    request: Request,
+    admin_session: str | None = Cookie(default=None),
+    admin_auth_service: AdminAuthService = Depends(get_admin_auth_service),
+) -> dict[str, int | str]:
+    try:
+        admin_data = admin_auth_service.get_authenticated_admin(admin_session)
+    except ValueError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid admin session",
+        )
+
+    request.state.admin_id = admin_data["id"]
+    request.state.admin_email = admin_data["email"]
+    return admin_data
+
+
+def get_owner_admin_context(
+    admin_context: dict[str, int | str] = Depends(get_authenticated_admin_context),
+) -> dict[str, int | str]:
+    if admin_context.get("role") != AdminRole.OWNER.value:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Owner access required",
+        )
+    return admin_context
 
 
 def get_stripe_payment_provider() -> StripePaymentProvider:

--- a/app/api/v1/endpoints/admin.py
+++ b/app/api/v1/endpoints/admin.py
@@ -1,0 +1,560 @@
+import math
+from datetime import datetime
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, HTTPException, Query, UploadFile, status
+from fastapi import Path as PathParam
+
+from app.api.dependencies import (
+    get_admin_auth_service,
+    get_admin_order_service,
+    get_admin_user_repository,
+    get_authenticated_admin_context,
+    get_email_log_repository,
+    get_order_repository,
+    get_owner_admin_context,
+    get_plan_repository,
+    get_user_repository,
+)
+from app.models.order import Order
+from app.repositories.admin_user_repository import AdminUserRepository
+from app.repositories.email_log_repository import EmailLogRepository
+from app.repositories.order_repository import OrderRepository
+from app.repositories.plan_repository import PlanRepository
+from app.repositories.user_repository import UserRepository
+from app.schemas.admin import (
+    AdminCustomerListItem,
+    AdminDocumentSummary,
+    AdminEmailLogItem,
+    AdminNotesUpdateRequest,
+    AdminOrderDetailResponse,
+    AdminOrderListItem,
+    AdminPaginatedCustomersResponse,
+    AdminPaginatedEmailLogsResponse,
+    AdminPaginatedOrdersResponse,
+    AdminPlanResponse,
+    AdminStaffListItem,
+    AdminStatsResponse,
+    CreateAdminUserRequest,
+    OrderApproveRequest,
+    PlanApprovalSettingRequest,
+    TemplateListItem,
+)
+from app.services.admin_auth_service import AdminAuthService
+from app.services.admin_order_service import AdminOrderService
+from app.services.admin_stats_service import AdminStatsService
+
+router = APIRouter()
+
+TEMPLATES_DIR = Path(__file__).parent.parent.parent.parent.parent / "templates" / "documents"
+
+
+def _build_order_list_item(order: Order) -> AdminOrderListItem:
+    os = order.order_status
+    return AdminOrderListItem(
+        order_id=order.id,
+        created_at=order.created_at,
+        order_status=os.order_status if os else "unknown",
+        payment_status=os.payment_status if os else "unknown",
+        total_amount=order.total_amount,
+        currency=os.currency if os else "CAD",
+        jurisdiction=order.jurisdiction,
+        company_name=order.company.name if order.company else None,
+        plan_name=order.plan.name if order.plan else None,
+        user_email=order.user.email if order.user else None,
+        user_full_name=order.user.full_name if order.user else None,
+        is_industry_specific=order.is_industry_specific,
+        admin_notes=order.admin_notes,
+    )
+
+
+def _build_order_detail(order: Order) -> AdminOrderDetailResponse:
+    os = order.order_status
+    documents = [
+        AdminDocumentSummary(
+            document_id=doc.document_id,
+            access_token=doc.access_token,
+            token_expires_at=doc.token_expires_at,
+            generated_at=doc.generated_at,
+            file_format=doc.file_format or "docx",
+            downloaded_count=doc.downloaded_count or 0,
+        )
+        for doc in (order.documents or [])
+    ]
+    email_logs = [
+        AdminEmailLogItem(
+            id=log.id,
+            order_id=log.order_id,
+            recipient_email=log.recipient_email,
+            subject=log.subject,
+            status=log.status,
+            sent_at=log.sent_at,
+            failure_reason=log.failure_reason,
+        )
+        for log in (order.email_logs or [])
+    ]
+
+    return AdminOrderDetailResponse(
+        order_id=order.id,
+        created_at=order.created_at,
+        completed_at=order.completed_at,
+        reviewed_at=order.reviewed_at,
+        reviewed_by_admin_id=order.reviewed_by_admin_id,
+        jurisdiction=order.jurisdiction,
+        total_amount=order.total_amount,
+        is_industry_specific=order.is_industry_specific,
+        admin_notes=order.admin_notes,
+        company_name=order.company.name if order.company else None,
+        plan_name=order.plan.name if order.plan else None,
+        order_status=os.order_status if os else "unknown",
+        payment_status=os.payment_status if os else "unknown",
+        currency=os.currency if os else "CAD",
+        user_email=order.user.email if order.user else None,
+        user_full_name=order.user.full_name if order.user else None,
+        documents=documents,
+        email_logs=email_logs,
+    )
+
+
+# ── Order Management ──
+
+
+@router.get(
+    "/orders",
+    response_model=AdminPaginatedOrdersResponse,
+    status_code=status.HTTP_200_OK,
+)
+def list_all_orders(
+    page: int = Query(1, ge=1),
+    page_size: int = Query(20, ge=1, le=100),
+    order_status: str | None = Query(None),
+    payment_status: str | None = Query(None),
+    plan_id: int | None = Query(None),
+    query: str | None = Query(None),
+    _admin: dict = Depends(get_authenticated_admin_context),
+    admin_order_service: AdminOrderService = Depends(get_admin_order_service),
+) -> AdminPaginatedOrdersResponse:
+    orders, total = admin_order_service.get_all_orders_paginated(
+        page=page,
+        page_size=page_size,
+        order_status=order_status,
+        payment_status=payment_status,
+        plan_id=plan_id,
+        query=query,
+    )
+    return AdminPaginatedOrdersResponse(
+        items=[_build_order_list_item(o) for o in orders],
+        total=total,
+        page=page,
+        page_size=page_size,
+        total_pages=math.ceil(total / page_size) if total > 0 else 0,
+    )
+
+
+@router.get(
+    "/orders/pending-review",
+    response_model=AdminPaginatedOrdersResponse,
+    status_code=status.HTTP_200_OK,
+)
+def list_pending_review_orders(
+    page: int = Query(1, ge=1),
+    page_size: int = Query(20, ge=1, le=100),
+    _admin: dict = Depends(get_authenticated_admin_context),
+    admin_order_service: AdminOrderService = Depends(get_admin_order_service),
+) -> AdminPaginatedOrdersResponse:
+    orders, total = admin_order_service.get_pending_review_orders(page=page, page_size=page_size)
+    return AdminPaginatedOrdersResponse(
+        items=[_build_order_list_item(o) for o in orders],
+        total=total,
+        page=page,
+        page_size=page_size,
+        total_pages=math.ceil(total / page_size) if total > 0 else 0,
+    )
+
+
+@router.get(
+    "/orders/{order_id}",
+    response_model=AdminOrderDetailResponse,
+    status_code=status.HTTP_200_OK,
+)
+def get_order_detail(
+    order_id: int = PathParam(..., gt=0),
+    _admin: dict = Depends(get_authenticated_admin_context),
+    admin_order_service: AdminOrderService = Depends(get_admin_order_service),
+) -> AdminOrderDetailResponse:
+    order = admin_order_service.get_order_detail(order_id)
+    return _build_order_detail(order)
+
+
+@router.post(
+    "/orders/{order_id}/approve",
+    response_model=AdminOrderDetailResponse,
+    status_code=status.HTTP_200_OK,
+)
+def approve_order(
+    order_id: int = PathParam(..., gt=0),
+    body: OrderApproveRequest | None = None,
+    admin_context: dict = Depends(get_authenticated_admin_context),
+    admin_order_service: AdminOrderService = Depends(get_admin_order_service),
+) -> AdminOrderDetailResponse:
+    if body and body.admin_notes:
+        admin_order_service.update_admin_notes(order_id, body.admin_notes)
+
+    order = admin_order_service.approve_order(order_id, admin_context["id"])
+    return _build_order_detail(order)
+
+
+@router.patch(
+    "/orders/{order_id}/notes",
+    response_model=AdminOrderDetailResponse,
+    status_code=status.HTTP_200_OK,
+)
+def update_order_notes(
+    body: AdminNotesUpdateRequest,
+    order_id: int = PathParam(..., gt=0),
+    _admin: dict = Depends(get_authenticated_admin_context),
+    admin_order_service: AdminOrderService = Depends(get_admin_order_service),
+) -> AdminOrderDetailResponse:
+    order = admin_order_service.update_admin_notes(order_id, body.admin_notes)
+    return _build_order_detail(order)
+
+
+@router.post(
+    "/orders/{order_id}/resend-email",
+    status_code=status.HTTP_200_OK,
+)
+def resend_order_email(
+    order_id: int = PathParam(..., gt=0),
+    _admin: dict = Depends(get_authenticated_admin_context),
+    admin_order_service: AdminOrderService = Depends(get_admin_order_service),
+) -> dict[str, str]:
+    admin_order_service.resend_delivery_email(order_id)
+    return {"message": "delivery email resent"}
+
+
+@router.post(
+    "/orders/{order_id}/regenerate-document",
+    status_code=status.HTTP_200_OK,
+)
+def regenerate_order_document(
+    order_id: int = PathParam(..., gt=0),
+    _admin: dict = Depends(get_authenticated_admin_context),
+    admin_order_service: AdminOrderService = Depends(get_admin_order_service),
+) -> dict[str, str]:
+    admin_order_service.regenerate_document(order_id)
+    return {"message": "document regenerated"}
+
+
+# ── Customer Viewing ──
+
+
+@router.get(
+    "/customers",
+    response_model=AdminPaginatedCustomersResponse,
+    status_code=status.HTTP_200_OK,
+)
+def list_customers(
+    page: int = Query(1, ge=1),
+    page_size: int = Query(20, ge=1, le=100),
+    query: str | None = Query(None),
+    _admin: dict = Depends(get_authenticated_admin_context),
+    user_repo: UserRepository = Depends(get_user_repository),
+    order_repo: OrderRepository = Depends(get_order_repository),
+) -> AdminPaginatedCustomersResponse:
+    from sqlalchemy import func
+
+    from app.models.order import Order
+    from app.models.user import User
+
+    skip = (page - 1) * page_size
+    base_q = user_repo.db.query(User)
+
+    if query:
+        base_q = base_q.filter(
+            (User.email.ilike(f"%{query}%")) | (User.full_name.ilike(f"%{query}%"))
+        )
+
+    total = base_q.count()
+
+    users = base_q.order_by(User.created_at.desc()).offset(skip).limit(page_size).all()
+
+    items = []
+    for user in users:
+        order_count = order_repo.db.query(func.count(Order.id)).filter(Order.user_id == user.id).scalar()
+        items.append(
+            AdminCustomerListItem(
+                id=user.id,
+                email=user.email,
+                full_name=user.full_name,
+                created_at=user.created_at,
+                last_login=user.last_login,
+                order_count=order_count or 0,
+            )
+        )
+
+    return AdminPaginatedCustomersResponse(
+        items=items,
+        total=total,
+        page=page,
+        page_size=page_size,
+        total_pages=math.ceil(total / page_size) if total > 0 else 0,
+    )
+
+
+@router.get(
+    "/customers/{user_id}",
+    response_model=AdminCustomerListItem,
+    status_code=status.HTTP_200_OK,
+)
+def get_customer_detail(
+    user_id: int = PathParam(..., gt=0),
+    _admin: dict = Depends(get_authenticated_admin_context),
+    user_repo: UserRepository = Depends(get_user_repository),
+    order_repo: OrderRepository = Depends(get_order_repository),
+) -> AdminCustomerListItem:
+    from sqlalchemy import func
+
+    from app.models.order import Order
+
+    user = user_repo.get_by_id_or_fail(user_id)
+    order_count = order_repo.db.query(func.count(Order.id)).filter(Order.user_id == user.id).scalar()
+
+    return AdminCustomerListItem(
+        id=user.id,
+        email=user.email,
+        full_name=user.full_name,
+        created_at=user.created_at,
+        last_login=user.last_login,
+        order_count=order_count or 0,
+    )
+
+
+# ── Plan Management ──
+
+
+@router.get(
+    "/plans",
+    response_model=list[AdminPlanResponse],
+    status_code=status.HTTP_200_OK,
+)
+def list_plans(
+    _admin: dict = Depends(get_authenticated_admin_context),
+    plan_repo: PlanRepository = Depends(get_plan_repository),
+) -> list[AdminPlanResponse]:
+    plans = plan_repo.get_all_plans()
+    return [AdminPlanResponse.model_validate(p) for p in plans]
+
+
+@router.patch(
+    "/plans/{plan_id}/approval-setting",
+    response_model=AdminPlanResponse,
+    status_code=status.HTTP_200_OK,
+)
+def update_plan_approval_setting(
+    body: PlanApprovalSettingRequest,
+    plan_id: int = PathParam(..., gt=0),
+    _admin: dict = Depends(get_owner_admin_context),
+    plan_repo: PlanRepository = Depends(get_plan_repository),
+) -> AdminPlanResponse:
+    plan = plan_repo.get_by_id_or_fail(plan_id)
+    plan.requires_approval = body.requires_approval
+    plan_repo.update(plan)
+    return AdminPlanResponse.model_validate(plan)
+
+
+# ── Template Management ──
+
+
+@router.get(
+    "/templates",
+    response_model=list[TemplateListItem],
+    status_code=status.HTTP_200_OK,
+)
+def list_templates(
+    _admin: dict = Depends(get_authenticated_admin_context),
+) -> list[TemplateListItem]:
+    if not TEMPLATES_DIR.exists():
+        return []
+
+    items = []
+    for file_path in sorted(TEMPLATES_DIR.glob("*.docx")):
+        slug = file_path.stem.replace("_manual_template", "")
+        stat = file_path.stat()
+        items.append(
+            TemplateListItem(
+                plan_slug=slug,
+                filename=file_path.name,
+                file_size_bytes=stat.st_size,
+                last_modified=datetime.fromtimestamp(stat.st_mtime),
+            )
+        )
+    return items
+
+
+@router.post(
+    "/templates/{plan_slug}",
+    status_code=status.HTTP_200_OK,
+)
+async def upload_template(
+    plan_slug: str,
+    file: UploadFile,
+    _admin: dict = Depends(get_owner_admin_context),
+) -> dict[str, str]:
+    if not file.filename or not file.filename.endswith(".docx"):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Only .docx files are accepted",
+        )
+
+    template_filename = f"{plan_slug}_manual_template.docx"
+    target_path = TEMPLATES_DIR / template_filename
+
+    if not TEMPLATES_DIR.exists():
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Templates directory not found",
+        )
+
+    content = await file.read()
+    target_path.write_bytes(content)
+
+    return {"message": f"template {template_filename} uploaded", "filename": template_filename}
+
+
+@router.get(
+    "/templates/{plan_slug}/download",
+    status_code=status.HTTP_200_OK,
+)
+def download_template(
+    plan_slug: str,
+    _admin: dict = Depends(get_authenticated_admin_context),
+):
+    from fastapi.responses import FileResponse
+
+    template_filename = f"{plan_slug}_manual_template.docx"
+    file_path = TEMPLATES_DIR / template_filename
+
+    if not file_path.exists():
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Template {template_filename} not found",
+        )
+
+    return FileResponse(
+        path=str(file_path),
+        filename=template_filename,
+        media_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    )
+
+
+# ── Dashboard Stats ──
+
+
+@router.get(
+    "/stats/dashboard",
+    response_model=AdminStatsResponse,
+    status_code=status.HTTP_200_OK,
+)
+def get_dashboard_stats(
+    _admin: dict = Depends(get_authenticated_admin_context),
+    order_repo: OrderRepository = Depends(get_order_repository),
+) -> AdminStatsResponse:
+    service = AdminStatsService(order_repo)
+    stats = service.get_dashboard_stats()
+    return AdminStatsResponse(**stats)
+
+
+# ── Email Logs ──
+
+
+@router.get(
+    "/logs/emails",
+    response_model=AdminPaginatedEmailLogsResponse,
+    status_code=status.HTTP_200_OK,
+)
+def list_email_logs(
+    page: int = Query(1, ge=1),
+    page_size: int = Query(20, ge=1, le=100),
+    email_status: str | None = Query(None),
+    order_id: int | None = Query(None),
+    _admin: dict = Depends(get_authenticated_admin_context),
+    email_log_repo: EmailLogRepository = Depends(get_email_log_repository),
+) -> AdminPaginatedEmailLogsResponse:
+    skip = (page - 1) * page_size
+    logs, total = email_log_repo.get_all_paginated(
+        skip=skip,
+        limit=page_size,
+        email_status=email_status,
+        order_id=order_id,
+    )
+    return AdminPaginatedEmailLogsResponse(
+        items=[AdminEmailLogItem.model_validate(log) for log in logs],
+        total=total,
+        page=page,
+        page_size=page_size,
+        total_pages=math.ceil(total / page_size) if total > 0 else 0,
+    )
+
+
+# ── Admin Staff Management (Owner only) ──
+
+
+@router.get(
+    "/staff",
+    response_model=list[AdminStaffListItem],
+    status_code=status.HTTP_200_OK,
+)
+def list_admin_staff(
+    _admin: dict = Depends(get_owner_admin_context),
+    admin_user_repo: AdminUserRepository = Depends(get_admin_user_repository),
+) -> list[AdminStaffListItem]:
+    admins, _ = admin_user_repo.get_all_paginated(skip=0, limit=100)
+    return [AdminStaffListItem.model_validate(a) for a in admins]
+
+
+@router.post(
+    "/staff",
+    response_model=AdminStaffListItem,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_admin_staff(
+    body: CreateAdminUserRequest,
+    _admin: dict = Depends(get_owner_admin_context),
+    admin_auth_service: AdminAuthService = Depends(get_admin_auth_service),
+) -> AdminStaffListItem:
+    try:
+        result = admin_auth_service.create_admin_user(
+            email=body.email,
+            full_name=body.full_name,
+            password=body.password,
+            role=body.role,
+        )
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        ) from None
+
+    admin_user_repo = admin_auth_service.admin_user_repo
+    admin = admin_user_repo.get_by_id_or_fail(result["id"])
+    return AdminStaffListItem.model_validate(admin)
+
+
+@router.patch(
+    "/staff/{admin_id}/deactivate",
+    response_model=AdminStaffListItem,
+    status_code=status.HTTP_200_OK,
+)
+def deactivate_admin_staff(
+    admin_id: int = PathParam(..., gt=0),
+    owner: dict = Depends(get_owner_admin_context),
+    admin_user_repo: AdminUserRepository = Depends(get_admin_user_repository),
+) -> AdminStaffListItem:
+    if admin_id == owner["id"]:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Cannot deactivate your own account",
+        )
+
+    admin = admin_user_repo.deactivate(admin_id)
+    return AdminStaffListItem.model_validate(admin)

--- a/app/api/v1/endpoints/admin_auth.py
+++ b/app/api/v1/endpoints/admin_auth.py
@@ -1,0 +1,89 @@
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+
+from app.api.dependencies import get_admin_auth_service, get_authenticated_admin_context
+from app.schemas.admin_auth import (
+    AdminChangePasswordRequest,
+    AdminLoginRequest,
+    AdminLoginResponse,
+    AdminUserResponse,
+)
+from app.services.admin_auth_service import AdminAuthService
+
+router = APIRouter()
+
+ADMIN_COOKIE_NAME = "admin_session"
+ADMIN_COOKIE_MAX_AGE = 60 * 60 * 8
+
+
+@router.post(
+    "/auth/login",
+    response_model=AdminLoginResponse,
+    status_code=status.HTTP_200_OK,
+)
+def admin_login(
+    body: AdminLoginRequest,
+    response: Response,
+    admin_auth_service: AdminAuthService = Depends(get_admin_auth_service),
+) -> AdminLoginResponse:
+    try:
+        result = admin_auth_service.login(body.email, body.password)
+    except ValueError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid credentials",
+        ) from None
+
+    response.set_cookie(
+        key=ADMIN_COOKIE_NAME,
+        value=result["session_token"],
+        httponly=True,
+        secure=True,
+        samesite="lax",
+        max_age=ADMIN_COOKIE_MAX_AGE,
+    )
+
+    return AdminLoginResponse(admin=AdminUserResponse(**result["admin"]))
+
+
+@router.get(
+    "/auth/me",
+    response_model=AdminUserResponse,
+    status_code=status.HTTP_200_OK,
+)
+def admin_me(
+    admin_context: dict[str, int | str] = Depends(get_authenticated_admin_context),
+) -> AdminUserResponse:
+    return AdminUserResponse(**admin_context)
+
+
+@router.post(
+    "/auth/logout",
+    status_code=status.HTTP_200_OK,
+)
+def admin_logout(response: Response) -> dict[str, str]:
+    response.delete_cookie(key=ADMIN_COOKIE_NAME)
+    return {"message": "logged out"}
+
+
+@router.post(
+    "/auth/change-password",
+    status_code=status.HTTP_200_OK,
+)
+def admin_change_password(
+    body: AdminChangePasswordRequest,
+    admin_context: dict[str, int | str] = Depends(get_authenticated_admin_context),
+    admin_auth_service: AdminAuthService = Depends(get_admin_auth_service),
+) -> dict[str, str]:
+    try:
+        admin_auth_service.change_password(
+            admin_id=admin_context["id"],
+            current_password=body.current_password,
+            new_password=body.new_password,
+        )
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        ) from None
+
+    return {"message": "password changed"}

--- a/app/api/v1/endpoints/payments.py
+++ b/app/api/v1/endpoints/payments.py
@@ -3,22 +3,17 @@ from decimal import Decimal
 from fastapi import APIRouter, Depends, HTTPException, Path, status
 
 from app.api.dependencies import (
-    get_document_repository,
-    get_email_service,
-    get_email_template_renderer,
+    get_order_fulfillment_service,
     get_order_repository,
     get_order_status_repository,
     get_payment_service,
 )
 from app.config import settings
 from app.repositories.base_repository import RecordNotFoundError
-from app.repositories.document_repository import DocumentRepository
 from app.repositories.order_repository import OrderRepository
 from app.repositories.order_status_repository import OrderStatusRepository
-from app.schemas.email import DocumentDeliveryContext
 from app.schemas.payment import CheckoutSessionResponse, StripeConfigResponse
-from app.services.email_service import EmailService
-from app.services.email_template_renderer import EmailTemplateRenderer
+from app.services.order_fulfillment_service import OrderFulfillmentService
 from app.services.payment_service import PaymentService
 
 router = APIRouter()
@@ -91,9 +86,7 @@ def create_checkout_session(
 def trigger_order_delivery(
     order_id: int = Path(..., gt=0),
     order_repo: OrderRepository = Depends(get_order_repository),
-    document_repo: DocumentRepository = Depends(get_document_repository),
-    renderer: EmailTemplateRenderer = Depends(get_email_template_renderer),
-    email_service: EmailService = Depends(get_email_service),
+    fulfillment_service: OrderFulfillmentService = Depends(get_order_fulfillment_service),
 ) -> dict:
     try:
         order = order_repo.get_by_id_with_relations(order_id)
@@ -103,27 +96,6 @@ def trigger_order_delivery(
     if not order:
         raise HTTPException(status_code=404, detail=f"Order {order_id} not found")
 
-    company_name = order.company.name if order.company else ""
-    recipient = order.user.email if order.user else ""
-
-    if not recipient:
-        raise HTTPException(status_code=400, detail="Order has no associated user email")
-
-    documents = document_repo.get_documents_by_order_id(order_id)
-    access_token = documents[0].access_token if documents else ""
-
-    download_link = f"{settings.app_base_url}/api/v1/documents/{order_id}/download"
-    if access_token:
-        download_link += f"?token={access_token}"
-
-    context_model = DocumentDeliveryContext(
-        order_id=order_id,
-        company_name=company_name or "",
-        download_link=download_link,
-        document_name=f"order_{order_id}_document.pdf",
-    )
-
-    html_body = renderer.render_document_delivery(context_model)
-    email_service.send_email(order_id, recipient, "Your documents are ready", html_body)
+    fulfillment_service.fulfill_order(order_id)
 
     return {"status": "delivery_triggered"}

--- a/app/api/v1/endpoints/webhooks.py
+++ b/app/api/v1/endpoints/webhooks.py
@@ -3,24 +3,16 @@ import logging
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 
 from app.api.dependencies import (
-    get_document_repository,
-    get_document_service,
-    get_email_service,
-    get_email_template_renderer,
+    get_order_fulfillment_service,
     get_order_repository,
     get_order_status_repository,
     get_payment_service,
 )
-from app.config import settings
-from app.models.order_status import PaymentStatus
-from app.repositories.document_repository import DocumentRepository
+from app.models.order_status import OrderStatusEnum, PaymentStatus
 from app.repositories.order_repository import OrderRepository
 from app.repositories.order_status_repository import OrderStatusRepository
-from app.schemas.email import DocumentDeliveryContext
 from app.schemas.payment import StripeWebhookEventType
-from app.services.document_service import DocumentService
-from app.services.email_service import EmailService
-from app.services.email_template_renderer import EmailTemplateRenderer
+from app.services.order_fulfillment_service import OrderFulfillmentService
 from app.services.payment_service import PaymentService
 
 logger = logging.getLogger(__name__)
@@ -37,10 +29,7 @@ async def handle_stripe_webhook(
     order_status_repo: OrderStatusRepository = Depends(get_order_status_repository),
     payment_service: PaymentService = Depends(get_payment_service),
     order_repo: OrderRepository = Depends(get_order_repository),
-    document_repo: DocumentRepository = Depends(get_document_repository),
-    document_service: DocumentService = Depends(get_document_service),
-    renderer: EmailTemplateRenderer = Depends(get_email_template_renderer),
-    email_service: EmailService = Depends(get_email_service),
+    fulfillment_service: OrderFulfillmentService = Depends(get_order_fulfillment_service),
 ) -> dict:
     signature = request.headers.get("stripe-signature") or request.headers.get("Stripe-Signature")
     body = await request.body()
@@ -72,10 +61,7 @@ async def handle_stripe_webhook(
             event=event,
             order_status_repo=order_status_repo,
             order_repo=order_repo,
-            document_repo=document_repo,
-            document_service=document_service,
-            renderer=renderer,
-            email_service=email_service,
+            fulfillment_service=fulfillment_service,
         )
 
     if event.event_type == StripeWebhookEventType.CHECKOUT_SESSION_EXPIRED:
@@ -106,10 +92,7 @@ def _handle_checkout_completed(
     event: object,
     order_status_repo: OrderStatusRepository,
     order_repo: OrderRepository,
-    document_repo: DocumentRepository,
-    document_service: DocumentService,
-    renderer: EmailTemplateRenderer,
-    email_service: EmailService,
+    fulfillment_service: OrderFulfillmentService,
 ) -> dict:
     order_status = order_status_repo.get_by_id(order_id)
     if order_status and order_status.payment_status == PaymentStatus.PAID.value:
@@ -120,14 +103,13 @@ def _handle_checkout_completed(
     if event.payment_intent_id:
         order_status_repo.update_stripe_payment_intent_id(order_id, event.payment_intent_id)
 
-    _generate_and_deliver(
-        order_id=order_id,
-        order_repo=order_repo,
-        document_repo=document_repo,
-        document_service=document_service,
-        renderer=renderer,
-        email_service=email_service,
-    )
+    order = order_repo.get_by_id_with_relations(order_id)
+    if order and order.plan and order.plan.requires_approval:
+        order_status_repo.update_order_status(order_id, OrderStatusEnum.REVIEW_PENDING)
+        logger.info("Order %d requires approval, set to review_pending", order_id)
+        return {"status": "ok", "action": "review_pending"}
+
+    fulfillment_service.fulfill_order(order_id)
 
     return {"status": "ok"}
 
@@ -161,53 +143,3 @@ def _handle_payment_intent_failed(
     return {"status": "ok", "action": "marked_failed"}
 
 
-def _generate_and_deliver(
-    order_id: int,
-    order_repo: OrderRepository,
-    document_repo: DocumentRepository,
-    document_service: DocumentService,
-    renderer: EmailTemplateRenderer,
-    email_service: EmailService,
-) -> None:
-    try:
-        order = order_repo.get_by_id_with_relations(order_id)
-    except Exception:
-        logger.error("Failed to fetch order %d for delivery", order_id, exc_info=True)
-        return
-
-    if not order or not order.user:
-        logger.warning("Order %d has no user, skipping delivery", order_id)
-        return
-
-    company_name = order.company.name if order.company else ""
-    recipient = order.user.email
-
-    documents = document_repo.get_documents_by_order_id(order_id)
-
-    if not documents:
-        try:
-            document = document_service.generate_document_for_order(order_id)
-            documents = [document]
-        except Exception:
-            logger.error("Document generation failed for order %d", order_id, exc_info=True)
-            return
-
-    access_token = documents[0].access_token if documents else ""
-    document_id = documents[0].document_id if documents else order_id
-
-    download_link = f"{settings.app_base_url}/api/v1/documents/{document_id}/download"
-    if access_token:
-        download_link += f"?token={access_token}"
-
-    context_model = DocumentDeliveryContext(
-        order_id=order_id,
-        company_name=company_name or "",
-        download_link=download_link,
-        document_name=f"order_{order_id}_document.pdf",
-    )
-    html_body = renderer.render_document_delivery(context_model)
-
-    try:
-        email_service.send_email(order_id, recipient, "Your documents are ready", html_body)
-    except Exception:
-        logger.error("Email delivery failed for order %d", order_id, exc_info=True)

--- a/app/api/v1/router.py
+++ b/app/api/v1/router.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from app.api.v1.endpoints import auth, documents, health, industry_intake, legal, orders, payments, plans, webhooks
+from app.api.v1.endpoints import admin, admin_auth, auth, documents, health, industry_intake, legal, orders, payments, plans, webhooks
 
 api_router = APIRouter()
 
@@ -13,3 +13,5 @@ api_router.include_router(legal.router, tags=["legal"])
 api_router.include_router(payments.router, prefix="/payments", tags=["payments"]) 
 api_router.include_router(webhooks.router, tags=["webhooks"])
 api_router.include_router(industry_intake.router, prefix="/industry", tags=["industry-intake"])
+api_router.include_router(admin_auth.router, prefix="/admin", tags=["admin-auth"])
+api_router.include_router(admin.router, prefix="/admin", tags=["admin"])

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -23,6 +23,7 @@ from .order_status import OrderStatus, OrderStatusEnum, PaymentStatus
 from .industry_intake_response import IndustryIntakeResponse
 from .auth_otp_request import AuthOtpRequest
 from .sjp_generation_job import SjpGenerationJob, SjpGenerationStatus
+from .admin_user import AdminUser, AdminRole
 
 __all__ = [
     "Plan",
@@ -51,4 +52,6 @@ __all__ = [
     "AuthOtpRequest",
     "SjpGenerationJob",
     "SjpGenerationStatus",
+    "AdminUser",
+    "AdminRole",
 ]

--- a/app/models/admin_user.py
+++ b/app/models/admin_user.py
@@ -1,0 +1,25 @@
+from datetime import UTC, datetime
+from enum import Enum
+
+from sqlalchemy import Boolean, Column, DateTime, Integer, String
+
+from app.database import Base
+
+
+class AdminRole(str, Enum):
+    OWNER = "owner"
+    MANAGER = "manager"
+    SUPPORT = "support"
+
+
+class AdminUser(Base):
+    __tablename__ = "admin_users"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    email = Column(String(255), nullable=False, unique=True)
+    full_name = Column(String(255), nullable=False)
+    role = Column(String(50), nullable=False, default=AdminRole.MANAGER.value)
+    password_hash = Column(String(255), nullable=False)
+    is_active = Column(Boolean, nullable=False, default=True)
+    created_at = Column(DateTime, nullable=False, default=lambda: datetime.now(UTC))
+    last_login = Column(DateTime, nullable=True)

--- a/app/models/order.py
+++ b/app/models/order.py
@@ -1,6 +1,6 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
-from sqlalchemy import Column, DateTime, Integer, String, Numeric, Boolean, Text, ForeignKey
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, Numeric, String, Text
 from sqlalchemy.orm import relationship
 
 from app.database import Base
@@ -15,12 +15,15 @@ class Order(Base):
     company_id = Column(Integer, ForeignKey("company.id", ondelete="NO ACTION", onupdate="NO ACTION"), nullable=False, index=True)
     jurisdiction = Column(String(100), nullable=False)
     total_amount = Column(Numeric(10, 2), nullable=False)
-    created_at = Column(DateTime, nullable=False, default=datetime.now(timezone.utc))
+    created_at = Column(DateTime, nullable=False, default=datetime.now(UTC))
     completed_at = Column(DateTime, nullable=True)
     is_industry_specific = Column(Boolean, nullable=False, default=False)
     admin_notes = Column(Text, nullable=True)
+    reviewed_by_admin_id = Column(Integer, ForeignKey("admin_users.id", ondelete="SET NULL"), nullable=True)
+    reviewed_at = Column(DateTime, nullable=True)
 
     user = relationship("User", back_populates="orders")
+    reviewed_by_admin = relationship("AdminUser", foreign_keys=[reviewed_by_admin_id])
     plan = relationship("Plan", back_populates="orders")
     company = relationship("Company", back_populates="orders")
     documents = relationship("Document", back_populates="order")

--- a/app/models/plan.py
+++ b/app/models/plan.py
@@ -1,5 +1,6 @@
 from enum import Enum
-from sqlalchemy import Column, Integer, String, Text, Numeric, Enum as SQLEnum
+
+from sqlalchemy import Boolean, Column, Integer, Numeric, String, Text
 from sqlalchemy.orm import relationship
 
 from app.database import Base
@@ -23,5 +24,6 @@ class Plan(Base):
     name = Column(String(100), nullable=False)
     description = Column(Text, nullable=True)
     base_price = Column(Numeric(10, 2), nullable=False)
+    requires_approval = Column(Boolean, nullable=False, default=False, server_default="0")
 
     orders = relationship("Order", back_populates="plan")

--- a/app/repositories/admin_user_repository.py
+++ b/app/repositories/admin_user_repository.py
@@ -1,0 +1,63 @@
+from datetime import datetime
+
+from sqlalchemy.orm import Session
+
+from app.models.admin_user import AdminRole, AdminUser
+from app.repositories.base_repository import BaseRepository, RecordNotFoundError
+
+
+class AdminUserRepository(BaseRepository[AdminUser]):
+    def __init__(self, db: Session):
+        super().__init__(AdminUser, db)
+
+    def get_by_email(self, email: str) -> AdminUser | None:
+        if not email:
+            raise ValueError("email is required")
+
+        return self.db.query(AdminUser).filter(AdminUser.email == email.strip().lower()).first()
+
+    def get_by_email_or_fail(self, email: str) -> AdminUser:
+        admin = self.get_by_email(email)
+        if not admin:
+            raise RecordNotFoundError(f"AdminUser with email {email} not found")
+        return admin
+
+    def get_all_paginated(
+        self,
+        skip: int = 0,
+        limit: int = 20,
+    ) -> tuple[list[AdminUser], int]:
+        query = self.db.query(AdminUser)
+        total = query.count()
+        items = query.order_by(AdminUser.created_at.desc()).offset(skip).limit(limit).all()
+        return items, total
+
+    def create_admin(
+        self,
+        email: str,
+        full_name: str,
+        password_hash: str,
+        role: AdminRole = AdminRole.MANAGER,
+    ) -> AdminUser:
+        admin = AdminUser(
+            email=email.strip().lower(),
+            full_name=full_name.strip(),
+            password_hash=password_hash,
+            role=role.value,
+        )
+        return self.create(admin)
+
+    def update_last_login(self, admin_id: int, login_time: datetime) -> AdminUser:
+        admin = self.get_by_id_or_fail(admin_id)
+        admin.last_login = login_time
+        return self.update(admin)
+
+    def update_password_hash(self, admin_id: int, password_hash: str) -> AdminUser:
+        admin = self.get_by_id_or_fail(admin_id)
+        admin.password_hash = password_hash
+        return self.update(admin)
+
+    def deactivate(self, admin_id: int) -> AdminUser:
+        admin = self.get_by_id_or_fail(admin_id)
+        admin.is_active = False
+        return self.update(admin)

--- a/app/repositories/email_log_repository.py
+++ b/app/repositories/email_log_repository.py
@@ -1,4 +1,6 @@
 from datetime import datetime, timezone
+
+from sqlalchemy import func, select
 from sqlalchemy.orm import Session, joinedload
 
 from app.models.email_log import EmailLog, EmailStatus
@@ -162,7 +164,7 @@ class EmailLogRepository(BaseRepository[EmailLog]):
     def get_failed_emails_for_retry(self, limit: int = 100) -> list[EmailLog]:
         if limit <= 0:
             raise ValueError("limit must be positive")
-        
+
         return (
             self.db.query(EmailLog)
             .options(joinedload(EmailLog.order))
@@ -171,3 +173,32 @@ class EmailLogRepository(BaseRepository[EmailLog]):
             .limit(limit)
             .all()
         )
+
+    def get_all_paginated(
+        self,
+        skip: int = 0,
+        limit: int = 20,
+        email_status: str | None = None,
+        order_id: int | None = None,
+    ) -> tuple[list[EmailLog], int]:
+        base_filter = []
+        if email_status is not None:
+            base_filter.append(EmailLog.status == email_status)
+        if order_id is not None:
+            base_filter.append(EmailLog.order_id == order_id)
+
+        count_q = select(func.count()).select_from(EmailLog)
+        if base_filter:
+            count_q = count_q.where(*base_filter)
+        total = self.db.execute(count_q).scalar_one()
+
+        items = (
+            self.db.query(EmailLog)
+            .options(joinedload(EmailLog.order))
+            .filter(*base_filter)
+            .order_by(EmailLog.sent_at.desc())
+            .offset(skip)
+            .limit(limit)
+            .all()
+        )
+        return items, total

--- a/app/repositories/order_repository.py
+++ b/app/repositories/order_repository.py
@@ -226,7 +226,7 @@ class OrderRepository(BaseRepository[Order]):
     def get_orders_by_jurisdiction(self, jurisdiction: str) -> list[Order]:
         if not jurisdiction:
             raise ValueError("jurisdiction is required")
-        
+
         return (
             self.db.query(Order)
             .options(
@@ -238,3 +238,140 @@ class OrderRepository(BaseRepository[Order]):
             .order_by(Order.created_at.desc())
             .all()
         )
+
+    def get_all_paginated(
+        self,
+        skip: int,
+        limit: int,
+        order_status: str | None = None,
+        payment_status: str | None = None,
+        plan_id: int | None = None,
+        query: str | None = None,
+    ) -> tuple[list[Order], int]:
+        base_filter = []
+        needs_status_join = order_status is not None or payment_status is not None
+        needs_company_join = query is not None and not query.isdigit()
+
+        if query is not None:
+            if query.isdigit():
+                base_filter.append(Order.id == int(query))
+            else:
+                base_filter.append(Company.name.ilike(f"%{query}%"))
+
+        if order_status is not None:
+            base_filter.append(OrderStatus.order_status == order_status)
+
+        if payment_status is not None:
+            base_filter.append(OrderStatus.payment_status == payment_status)
+
+        if plan_id is not None:
+            base_filter.append(Order.plan_id == plan_id)
+
+        count_q = select(func.count()).select_from(Order)
+        if needs_status_join:
+            count_q = count_q.join(OrderStatus, Order.id == OrderStatus.order_id)
+        if needs_company_join:
+            count_q = count_q.join(Company, Order.company_id == Company.id)
+        if base_filter:
+            count_q = count_q.where(*base_filter)
+        total = self.db.execute(count_q).scalar_one()
+
+        list_q = self.db.query(Order)
+        if needs_status_join:
+            list_q = list_q.join(OrderStatus, Order.id == OrderStatus.order_id)
+        if needs_company_join:
+            list_q = list_q.join(Company, Order.company_id == Company.id)
+        list_q = (
+            list_q.options(
+                joinedload(Order.user),
+                joinedload(Order.order_status),
+                joinedload(Order.company),
+                joinedload(Order.plan),
+                joinedload(Order.documents),
+            )
+            .filter(*base_filter)
+            .order_by(Order.created_at.desc())
+            .offset(skip)
+            .limit(limit)
+        )
+        return list_q.all(), total
+
+    def get_review_pending_paginated(
+        self,
+        skip: int,
+        limit: int,
+    ) -> tuple[list[Order], int]:
+        count_q = (
+            select(func.count())
+            .select_from(Order)
+            .join(OrderStatus, Order.id == OrderStatus.order_id)
+            .where(OrderStatus.order_status == OrderStatusEnum.REVIEW_PENDING.value)
+        )
+        total = self.db.execute(count_q).scalar_one()
+
+        items = (
+            self.db.query(Order)
+            .join(OrderStatus, Order.id == OrderStatus.order_id)
+            .options(
+                joinedload(Order.user),
+                joinedload(Order.order_status),
+                joinedload(Order.company),
+                joinedload(Order.plan),
+            )
+            .filter(OrderStatus.order_status == OrderStatusEnum.REVIEW_PENDING.value)
+            .order_by(Order.created_at.asc())
+            .offset(skip)
+            .limit(limit)
+            .all()
+        )
+        return items, total
+
+    def get_revenue_stats(self) -> dict:
+        from app.models.plan import Plan
+
+        total_revenue = (
+            self.db.query(func.coalesce(func.sum(Order.total_amount), 0))
+            .join(OrderStatus, Order.id == OrderStatus.order_id)
+            .filter(OrderStatus.payment_status == PaymentStatus.PAID.value)
+            .scalar()
+        )
+
+        total_orders = self.db.query(func.count(Order.id)).scalar()
+
+        status_counts = (
+            self.db.query(OrderStatus.order_status, func.count(OrderStatus.order_id))
+            .group_by(OrderStatus.order_status)
+            .all()
+        )
+
+        plan_stats = (
+            self.db.query(
+                Plan.name,
+                func.count(Order.id),
+                func.coalesce(func.sum(Order.total_amount), 0),
+            )
+            .join(Order, Plan.id == Order.plan_id)
+            .join(OrderStatus, Order.id == OrderStatus.order_id)
+            .filter(OrderStatus.payment_status == PaymentStatus.PAID.value)
+            .group_by(Plan.name)
+            .all()
+        )
+
+        return {
+            "total_revenue": total_revenue,
+            "total_orders": total_orders,
+            "orders_by_status": {row[0]: row[1] for row in status_counts},
+            "orders_by_plan": {row[0]: row[1] for row in plan_stats},
+            "revenue_by_plan": {row[0]: row[2] for row in plan_stats},
+        }
+
+    def update_review_info(
+        self,
+        order_id: int,
+        admin_id: int,
+        reviewed_at: datetime,
+    ) -> Order:
+        order = self.get_by_id_or_fail(order_id)
+        order.reviewed_by_admin_id = admin_id
+        order.reviewed_at = reviewed_at
+        return self.update(order)

--- a/app/schemas/admin.py
+++ b/app/schemas/admin.py
@@ -1,0 +1,155 @@
+from datetime import datetime
+from decimal import Decimal
+
+from pydantic import BaseModel
+
+
+class AdminOrderListItem(BaseModel):
+    order_id: int
+    created_at: datetime
+    order_status: str
+    payment_status: str
+    total_amount: Decimal
+    currency: str
+    jurisdiction: str
+    company_name: str | None = None
+    plan_name: str | None = None
+    user_email: str | None = None
+    user_full_name: str | None = None
+    is_industry_specific: bool
+    admin_notes: str | None = None
+
+
+class AdminPaginatedOrdersResponse(BaseModel):
+    items: list[AdminOrderListItem]
+    total: int
+    page: int
+    page_size: int
+    total_pages: int
+
+
+class AdminEmailLogItem(BaseModel):
+    id: int
+    order_id: int
+    recipient_email: str
+    subject: str
+    status: str
+    sent_at: datetime
+    failure_reason: str | None = None
+
+    model_config = {"from_attributes": True}
+
+
+class AdminDocumentSummary(BaseModel):
+    document_id: int
+    access_token: str
+    token_expires_at: datetime
+    generated_at: datetime
+    file_format: str
+    downloaded_count: int
+
+    model_config = {"from_attributes": True}
+
+
+class AdminOrderDetailResponse(BaseModel):
+    order_id: int
+    created_at: datetime
+    completed_at: datetime | None = None
+    reviewed_at: datetime | None = None
+    reviewed_by_admin_id: int | None = None
+    jurisdiction: str
+    total_amount: Decimal
+    is_industry_specific: bool
+    admin_notes: str | None = None
+    company_name: str | None = None
+    plan_name: str | None = None
+    order_status: str
+    payment_status: str
+    currency: str
+    user_email: str | None = None
+    user_full_name: str | None = None
+    documents: list[AdminDocumentSummary] = []
+    email_logs: list[AdminEmailLogItem] = []
+
+
+class OrderApproveRequest(BaseModel):
+    admin_notes: str | None = None
+
+
+class AdminNotesUpdateRequest(BaseModel):
+    admin_notes: str
+
+
+class AdminCustomerListItem(BaseModel):
+    id: int
+    email: str
+    full_name: str
+    created_at: datetime | None = None
+    last_login: datetime | None = None
+    order_count: int = 0
+
+
+class AdminPaginatedCustomersResponse(BaseModel):
+    items: list[AdminCustomerListItem]
+    total: int
+    page: int
+    page_size: int
+    total_pages: int
+
+
+class AdminPlanResponse(BaseModel):
+    id: int
+    slug: str
+    name: str
+    description: str | None = None
+    base_price: Decimal
+    requires_approval: bool
+
+    model_config = {"from_attributes": True}
+
+
+class PlanApprovalSettingRequest(BaseModel):
+    requires_approval: bool
+
+
+class AdminStatsResponse(BaseModel):
+    total_revenue: Decimal
+    total_orders: int
+    orders_by_status: dict[str, int]
+    orders_by_plan: dict[str, int]
+    revenue_by_plan: dict[str, Decimal]
+    pending_review_count: int
+
+
+class AdminPaginatedEmailLogsResponse(BaseModel):
+    items: list[AdminEmailLogItem]
+    total: int
+    page: int
+    page_size: int
+    total_pages: int
+
+
+class TemplateListItem(BaseModel):
+    plan_slug: str
+    filename: str
+    file_size_bytes: int
+    last_modified: datetime
+
+
+class CreateAdminUserRequest(BaseModel):
+    email: str
+    full_name: str
+    password: str
+    role: str = "manager"
+
+
+class AdminStaffListItem(BaseModel):
+    id: int
+    email: str
+    full_name: str
+    role: str
+    is_active: bool
+    created_at: datetime
+    last_login: datetime | None = None
+
+    model_config = {"from_attributes": True}

--- a/app/schemas/admin_auth.py
+++ b/app/schemas/admin_auth.py
@@ -1,0 +1,24 @@
+from pydantic import BaseModel
+
+
+class AdminLoginRequest(BaseModel):
+    email: str
+    password: str
+
+
+class AdminUserResponse(BaseModel):
+    id: int
+    email: str
+    full_name: str
+    role: str
+
+    model_config = {"from_attributes": True}
+
+
+class AdminLoginResponse(BaseModel):
+    admin: AdminUserResponse
+
+
+class AdminChangePasswordRequest(BaseModel):
+    current_password: str
+    new_password: str

--- a/app/schemas/plan.py
+++ b/app/schemas/plan.py
@@ -9,7 +9,8 @@ class PlanResponse(BaseModel):
     name: str
     description: str | None = None
     base_price: Decimal = Field(..., description="Base price in CAD")
-    
+    requires_approval: bool = False
+
     model_config = {
         "from_attributes": True,
         "json_schema_extra": {

--- a/app/services/admin_auth_service.py
+++ b/app/services/admin_auth_service.py
@@ -1,0 +1,198 @@
+import base64
+import hashlib
+import hmac
+import json
+from datetime import UTC, datetime, timedelta
+
+import bcrypt as _bcrypt
+
+from app.config import Settings
+from app.repositories.admin_user_repository import AdminUserRepository
+
+ADMIN_SESSION_AUDIENCE = "ohs-admin-auth"
+ADMIN_SESSION_EXPIRY_MINUTES = 480
+
+
+class AdminAuthService:
+    def __init__(
+        self,
+        admin_user_repo: AdminUserRepository,
+        settings: Settings,
+    ):
+        self.admin_user_repo = admin_user_repo
+        self.settings = settings
+
+    def login(self, email: str, password: str) -> dict[str, str | dict[str, int | str]]:
+        if not email or not password:
+            raise ValueError("email and password are required")
+
+        normalized_email = email.strip().lower()
+        admin = self.admin_user_repo.get_by_email(normalized_email)
+        if not admin:
+            raise ValueError("invalid credentials")
+
+        if not admin.is_active:
+            raise ValueError("account is deactivated")
+
+        if not _bcrypt.checkpw(password.encode(), admin.password_hash.encode()):
+            raise ValueError("invalid credentials")
+
+        now = datetime.now(UTC)
+        self.admin_user_repo.update_last_login(admin.id, now)
+
+        session_token = self._build_session_token(admin.id, admin.email, admin.role, now)
+
+        return {
+            "session_token": session_token,
+            "admin": {
+                "id": int(admin.id),
+                "email": str(admin.email),
+                "full_name": str(admin.full_name),
+                "role": str(admin.role),
+            },
+        }
+
+    def get_authenticated_admin(self, session_token: str | None) -> dict[str, int | str]:
+        if not session_token:
+            raise ValueError("invalid admin session")
+
+        try:
+            payload_segment, signature_segment = session_token.split(".", 1)
+        except ValueError:
+            raise ValueError("invalid admin session") from None
+
+        expected_signature = hmac.new(
+            self.settings.secret_key.encode("utf-8"),
+            payload_segment.encode("utf-8"),
+            hashlib.sha256,
+        ).digest()
+        expected_signature_b64 = base64.urlsafe_b64encode(expected_signature).decode("utf-8").rstrip("=")
+
+        if not hmac.compare_digest(signature_segment, expected_signature_b64):
+            raise ValueError("invalid admin session")
+
+        payload = self._decode_payload(payload_segment)
+
+        if payload.get("audience") != ADMIN_SESSION_AUDIENCE:
+            raise ValueError("invalid admin session")
+
+        expiry = payload.get("expiry")
+        if not expiry:
+            raise ValueError("invalid admin session")
+
+        expires_at = datetime.fromisoformat(str(expiry))
+        if expires_at.tzinfo is None:
+            expires_at = expires_at.replace(tzinfo=UTC)
+        if datetime.now(UTC) > expires_at:
+            raise ValueError("invalid admin session")
+
+        admin_email = payload.get("email")
+        if not isinstance(admin_email, str) or not admin_email:
+            raise ValueError("invalid admin session")
+
+        admin = self.admin_user_repo.get_by_email(admin_email)
+        if not admin:
+            raise ValueError("invalid admin session")
+
+        if not admin.is_active:
+            raise ValueError("invalid admin session")
+
+        return {
+            "id": int(admin.id),
+            "email": str(admin.email),
+            "full_name": str(admin.full_name),
+            "role": str(admin.role),
+        }
+
+    def change_password(
+        self,
+        admin_id: int,
+        current_password: str,
+        new_password: str,
+    ) -> None:
+        if not current_password or not new_password:
+            raise ValueError("current_password and new_password are required")
+
+        if len(new_password) < 8:
+            raise ValueError("new_password must be at least 8 characters")
+
+        admin = self.admin_user_repo.get_by_id_or_fail(admin_id)
+
+        if not _bcrypt.checkpw(current_password.encode(), admin.password_hash.encode()):
+            raise ValueError("current password is incorrect")
+
+        new_hash = _bcrypt.hashpw(new_password.encode(), _bcrypt.gensalt()).decode()
+        self.admin_user_repo.update_password_hash(admin_id, new_hash)
+
+    def create_admin_user(
+        self,
+        email: str,
+        full_name: str,
+        password: str,
+        role: str,
+    ) -> dict[str, int | str]:
+        if not email or not full_name or not password:
+            raise ValueError("email, full_name, and password are required")
+
+        if len(password) < 8:
+            raise ValueError("password must be at least 8 characters")
+
+        from app.models.admin_user import AdminRole
+
+        try:
+            admin_role = AdminRole(role)
+        except ValueError:
+            raise ValueError(f"invalid role: {role}") from None
+
+        existing = self.admin_user_repo.get_by_email(email.strip().lower())
+        if existing:
+            raise ValueError("an admin with this email already exists")
+
+        password_hash = _bcrypt.hashpw(password.encode(), _bcrypt.gensalt()).decode()
+        admin = self.admin_user_repo.create_admin(
+            email=email,
+            full_name=full_name,
+            password_hash=password_hash,
+            role=admin_role,
+        )
+
+        return {
+            "id": int(admin.id),
+            "email": str(admin.email),
+            "full_name": str(admin.full_name),
+            "role": str(admin.role),
+        }
+
+    def _build_session_token(
+        self,
+        admin_id: int,
+        email: str,
+        role: str,
+        issued_at: datetime,
+    ) -> str:
+        expires_at = issued_at + timedelta(minutes=ADMIN_SESSION_EXPIRY_MINUTES)
+        payload = {
+            "admin_id": admin_id,
+            "email": email,
+            "role": role,
+            "issued_at": issued_at.isoformat(),
+            "expiry": expires_at.isoformat(),
+            "audience": ADMIN_SESSION_AUDIENCE,
+        }
+        payload_json = json.dumps(payload, separators=(",", ":"), sort_keys=True)
+        payload_b64 = base64.urlsafe_b64encode(payload_json.encode("utf-8")).decode("utf-8").rstrip("=")
+        signature = hmac.new(
+            self.settings.secret_key.encode("utf-8"),
+            payload_b64.encode("utf-8"),
+            hashlib.sha256,
+        ).digest()
+        signature_b64 = base64.urlsafe_b64encode(signature).decode("utf-8").rstrip("=")
+        return f"{payload_b64}.{signature_b64}"
+
+    def _decode_payload(self, payload_segment: str) -> dict[str, object]:
+        padded = payload_segment + "=" * (-len(payload_segment) % 4)
+        try:
+            decoded = base64.urlsafe_b64decode(padded.encode("utf-8"))
+            return json.loads(decoded.decode("utf-8"))
+        except (ValueError, json.JSONDecodeError, UnicodeDecodeError):
+            raise ValueError("invalid admin session") from None

--- a/app/services/admin_order_service.py
+++ b/app/services/admin_order_service.py
@@ -1,0 +1,99 @@
+from datetime import UTC, datetime
+
+from app.models.order import Order
+from app.models.order_status import OrderStatusEnum, PaymentStatus
+from app.repositories.order_repository import OrderRepository
+from app.repositories.order_status_repository import OrderStatusRepository
+from app.services.exceptions import InvalidOrderStateException
+from app.services.order_fulfillment_service import OrderFulfillmentService
+
+
+class AdminOrderService:
+    def __init__(
+        self,
+        order_repo: OrderRepository,
+        order_status_repo: OrderStatusRepository,
+        fulfillment_service: OrderFulfillmentService,
+    ):
+        self.order_repo = order_repo
+        self.order_status_repo = order_status_repo
+        self.fulfillment_service = fulfillment_service
+
+    def approve_order(self, order_id: int, admin_id: int) -> Order:
+        order = self.order_repo.get_by_id_with_relations(order_id)
+        if not order:
+            raise InvalidOrderStateException(f"Order {order_id} not found")
+
+        if not order.order_status or order.order_status.order_status != OrderStatusEnum.REVIEW_PENDING.value:
+            raise InvalidOrderStateException(
+                f"Order {order_id} is not in review_pending status"
+            )
+
+        order.reviewed_by_admin_id = admin_id
+        order.reviewed_at = datetime.now(UTC)
+        self.order_repo.update(order)
+
+        self.fulfillment_service.fulfill_order(order_id)
+
+        return self.order_repo.get_by_id_with_relations(order_id)
+
+    def get_all_orders_paginated(
+        self,
+        page: int = 1,
+        page_size: int = 20,
+        order_status: str | None = None,
+        payment_status: str | None = None,
+        plan_id: int | None = None,
+        query: str | None = None,
+    ) -> tuple[list[Order], int]:
+        skip = (page - 1) * page_size
+        return self.order_repo.get_all_paginated(
+            skip=skip,
+            limit=page_size,
+            order_status=order_status,
+            payment_status=payment_status,
+            plan_id=plan_id,
+            query=query,
+        )
+
+    def get_pending_review_orders(
+        self,
+        page: int = 1,
+        page_size: int = 20,
+    ) -> tuple[list[Order], int]:
+        skip = (page - 1) * page_size
+        return self.order_repo.get_review_pending_paginated(skip=skip, limit=page_size)
+
+    def get_order_detail(self, order_id: int) -> Order:
+        order = self.order_repo.get_by_id_with_relations(order_id)
+        if not order:
+            raise InvalidOrderStateException(f"Order {order_id} not found")
+        return order
+
+    def update_admin_notes(self, order_id: int, admin_notes: str) -> Order:
+        order = self.order_repo.get_by_id_with_relations(order_id)
+        if not order:
+            raise InvalidOrderStateException(f"Order {order_id} not found")
+
+        order.admin_notes = admin_notes
+        return self.order_repo.update(order)
+
+    def resend_delivery_email(self, order_id: int) -> None:
+        order = self.order_repo.get_by_id_with_relations(order_id)
+        if not order:
+            raise InvalidOrderStateException(f"Order {order_id} not found")
+
+        if not order.order_status or order.order_status.payment_status != PaymentStatus.PAID.value:
+            raise InvalidOrderStateException(f"Order {order_id} payment is not completed")
+
+        self.fulfillment_service.fulfill_order(order_id)
+
+    def regenerate_document(self, order_id: int) -> None:
+        order = self.order_repo.get_by_id_with_relations(order_id)
+        if not order:
+            raise InvalidOrderStateException(f"Order {order_id} not found")
+
+        if not order.order_status or order.order_status.payment_status != PaymentStatus.PAID.value:
+            raise InvalidOrderStateException(f"Order {order_id} payment is not completed")
+
+        self.fulfillment_service.document_service.generate_document_for_order(order_id)

--- a/app/services/admin_stats_service.py
+++ b/app/services/admin_stats_service.py
@@ -1,0 +1,27 @@
+from decimal import Decimal
+
+from app.models.order_status import OrderStatusEnum
+from app.repositories.order_repository import OrderRepository
+
+
+class AdminStatsService:
+    def __init__(self, order_repo: OrderRepository):
+        self.order_repo = order_repo
+
+    def get_dashboard_stats(self) -> dict:
+        stats = self.order_repo.get_revenue_stats()
+
+        pending_review_count = stats["orders_by_status"].get(
+            OrderStatusEnum.REVIEW_PENDING.value, 0
+        )
+
+        return {
+            "total_revenue": Decimal(str(stats["total_revenue"])),
+            "total_orders": stats["total_orders"],
+            "orders_by_status": stats["orders_by_status"],
+            "orders_by_plan": stats["orders_by_plan"],
+            "revenue_by_plan": {
+                k: Decimal(str(v)) for k, v in stats["revenue_by_plan"].items()
+            },
+            "pending_review_count": pending_review_count,
+        }

--- a/app/services/order_fulfillment_service.py
+++ b/app/services/order_fulfillment_service.py
@@ -1,0 +1,79 @@
+import logging
+from datetime import UTC, datetime
+
+from app.config import settings
+from app.models.order_status import OrderStatusEnum
+from app.repositories.document_repository import DocumentRepository
+from app.repositories.order_repository import OrderRepository
+from app.repositories.order_status_repository import OrderStatusRepository
+from app.schemas.email import DocumentDeliveryContext
+from app.services.document_service import DocumentService
+from app.services.email_service import EmailService
+from app.services.email_template_renderer import EmailTemplateRenderer
+
+logger = logging.getLogger(__name__)
+
+
+class OrderFulfillmentService:
+    def __init__(
+        self,
+        order_repo: OrderRepository,
+        order_status_repo: OrderStatusRepository,
+        document_repo: DocumentRepository,
+        document_service: DocumentService,
+        email_service: EmailService,
+        email_template_renderer: EmailTemplateRenderer,
+    ):
+        self.order_repo = order_repo
+        self.order_status_repo = order_status_repo
+        self.document_repo = document_repo
+        self.document_service = document_service
+        self.email_service = email_service
+        self.email_template_renderer = email_template_renderer
+
+    def fulfill_order(self, order_id: int) -> None:
+        try:
+            order = self.order_repo.get_by_id_with_relations(order_id)
+        except Exception:
+            logger.error("Failed to fetch order %d for delivery", order_id, exc_info=True)
+            return
+
+        if not order or not order.user:
+            logger.warning("Order %d has no user, skipping delivery", order_id)
+            return
+
+        company_name = order.company.name if order.company else ""
+        recipient = order.user.email
+
+        documents = self.document_repo.get_documents_by_order_id(order_id)
+
+        if not documents:
+            try:
+                document = self.document_service.generate_document_for_order(order_id)
+                documents = [document]
+            except Exception:
+                logger.error("Document generation failed for order %d", order_id, exc_info=True)
+                return
+
+        access_token = documents[0].access_token if documents else ""
+        document_id = documents[0].document_id if documents else order_id
+
+        download_link = f"{settings.app_base_url}/api/v1/documents/{document_id}/download"
+        if access_token:
+            download_link += f"?token={access_token}"
+
+        context_model = DocumentDeliveryContext(
+            order_id=order_id,
+            company_name=company_name or "",
+            download_link=download_link,
+            document_name=f"order_{order_id}_document.pdf",
+        )
+        html_body = self.email_template_renderer.render_document_delivery(context_model)
+
+        try:
+            self.email_service.send_email(order_id, recipient, "Your documents are ready", html_body)
+        except Exception:
+            logger.error("Email delivery failed for order %d", order_id, exc_info=True)
+
+        self.order_status_repo.update_order_status(order_id, OrderStatusEnum.AVAILABLE)
+        self.order_repo.update_completed_at(order_id, datetime.now(UTC))

--- a/docs/ADMIN_API.md
+++ b/docs/ADMIN_API.md
@@ -1,0 +1,779 @@
+# Admin Panel API Documentation
+
+Base URL: `{API_BASE_URL}/api/v1/admin`
+
+All admin endpoints are under the `/admin` prefix. The admin system is **completely separate** from the customer system — different database table, different auth mechanism, different session cookie.
+
+---
+
+## Table of Contents
+
+- [Authentication](#authentication)
+- [Order Management](#order-management)
+- [Approval Workflow](#approval-workflow)
+- [Customers](#customers)
+- [Plans](#plans)
+- [Templates](#templates)
+- [Dashboard Stats](#dashboard-stats)
+- [Email Logs](#email-logs)
+- [Staff Management](#staff-management)
+- [Enums & Constants](#enums--constants)
+- [Error Handling](#error-handling)
+
+---
+
+## Authentication
+
+Admin auth uses **email + password** (not OTP). The session is stored in an HTTP-only cookie named `admin_session` (8-hour expiry). The frontend does **not** need to manage tokens — the browser sends the cookie automatically on every request.
+
+> The admin cookie (`admin_session`) is completely separate from the customer cookie (`auth_session`). A customer token cannot be used on admin endpoints and vice versa.
+
+### Admin Roles
+
+| Role | Access Level |
+|------|-------------|
+| `owner` | Full access. Can manage staff, change plan settings, upload templates. |
+| `manager` | Can manage orders, view customers, view stats, approve orders. |
+| `support` | Same as manager. |
+
+### Login
+
+```
+POST /admin/auth/login
+```
+
+**Request Body:**
+```json
+{
+  "email": "admin@ohsremote.com",
+  "password": "your_password"
+}
+```
+
+**Response `200`:**
+```json
+{
+  "admin": {
+    "id": 1,
+    "email": "admin@ohsremote.com",
+    "full_name": "System Admin",
+    "role": "owner"
+  }
+}
+```
+
+**Response `401`:** Invalid credentials.
+
+**Side effect:** Sets `admin_session` cookie (httpOnly, secure, sameSite=lax, maxAge=28800s).
+
+### Get Current Admin
+
+```
+GET /admin/auth/me
+```
+
+**Response `200`:**
+```json
+{
+  "id": 1,
+  "email": "admin@ohsremote.com",
+  "full_name": "System Admin",
+  "role": "owner"
+}
+```
+
+**Response `401`:** Not authenticated or session expired.
+
+### Logout
+
+```
+POST /admin/auth/logout
+```
+
+**Response `200`:**
+```json
+{
+  "message": "logged out"
+}
+```
+
+**Side effect:** Deletes `admin_session` cookie.
+
+### Change Password
+
+```
+POST /admin/auth/change-password
+```
+
+**Auth:** Any authenticated admin.
+
+**Request Body:**
+```json
+{
+  "current_password": "old_password",
+  "new_password": "new_password_min_8_chars"
+}
+```
+
+**Response `200`:**
+```json
+{
+  "message": "password changed"
+}
+```
+
+**Response `400`:** Current password incorrect or new password too short (min 8 chars).
+
+---
+
+## Order Management
+
+### List All Orders
+
+```
+GET /admin/orders
+```
+
+**Auth:** Any admin role.
+
+**Query Parameters:**
+
+| Param | Type | Default | Description |
+|-------|------|---------|-------------|
+| `page` | int | 1 | Page number (min 1) |
+| `page_size` | int | 20 | Items per page (1-100) |
+| `order_status` | string | null | Filter: `draft`, `processing`, `review_pending`, `available`, `cancelled` |
+| `payment_status` | string | null | Filter: `pending`, `paid`, `failed`, `refunded` |
+| `plan_id` | int | null | Filter by plan ID |
+| `query` | string | null | Search by order ID (numeric) or company name (text) |
+
+**Response `200`:**
+```json
+{
+  "items": [
+    {
+      "order_id": 42,
+      "created_at": "2026-04-01T14:30:00",
+      "order_status": "review_pending",
+      "payment_status": "paid",
+      "total_amount": "99.99",
+      "currency": "CAD",
+      "jurisdiction": "ON",
+      "company_name": "Acme Corp",
+      "plan_name": "Basic",
+      "user_email": "customer@example.com",
+      "user_full_name": "John Doe",
+      "is_industry_specific": false,
+      "admin_notes": null
+    }
+  ],
+  "total": 156,
+  "page": 1,
+  "page_size": 20,
+  "total_pages": 8
+}
+```
+
+### List Orders Pending Review
+
+```
+GET /admin/orders/pending-review
+```
+
+**Auth:** Any admin role.
+
+**Query Parameters:** `page`, `page_size` (same as above).
+
+**Response:** Same shape as `GET /admin/orders`. Only returns orders with `order_status = "review_pending"`. Sorted oldest first (FIFO queue).
+
+### Get Order Detail
+
+```
+GET /admin/orders/{order_id}
+```
+
+**Auth:** Any admin role.
+
+**Response `200`:**
+```json
+{
+  "order_id": 42,
+  "created_at": "2026-04-01T14:30:00",
+  "completed_at": null,
+  "reviewed_at": null,
+  "reviewed_by_admin_id": null,
+  "jurisdiction": "ON",
+  "total_amount": "99.99",
+  "is_industry_specific": false,
+  "admin_notes": null,
+  "company_name": "Acme Corp",
+  "plan_name": "Basic",
+  "order_status": "review_pending",
+  "payment_status": "paid",
+  "currency": "CAD",
+  "user_email": "customer@example.com",
+  "user_full_name": "John Doe",
+  "documents": [
+    {
+      "document_id": 15,
+      "access_token": "abc123...",
+      "token_expires_at": "2026-05-01T14:30:00",
+      "generated_at": "2026-04-01T14:35:00",
+      "file_format": "docx",
+      "downloaded_count": 3
+    }
+  ],
+  "email_logs": [
+    {
+      "id": 8,
+      "order_id": 42,
+      "recipient_email": "customer@example.com",
+      "subject": "Your documents are ready",
+      "status": "delivered",
+      "sent_at": "2026-04-01T14:36:00",
+      "failure_reason": null
+    }
+  ]
+}
+```
+
+### Update Order Notes
+
+```
+PATCH /admin/orders/{order_id}/notes
+```
+
+**Auth:** Any admin role.
+
+**Request Body:**
+```json
+{
+  "admin_notes": "Reviewed company registration, all clear."
+}
+```
+
+**Response `200`:** Full `AdminOrderDetailResponse` (same as GET detail).
+
+### Resend Delivery Email
+
+```
+POST /admin/orders/{order_id}/resend-email
+```
+
+**Auth:** Any admin role. Order must have `payment_status = "paid"`.
+
+**Response `200`:**
+```json
+{
+  "message": "delivery email resent"
+}
+```
+
+This re-triggers document generation (if no document exists) and sends the delivery email to the customer again. Useful when the customer reports they didn't receive it.
+
+### Regenerate Document
+
+```
+POST /admin/orders/{order_id}/regenerate-document
+```
+
+**Auth:** Any admin role. Order must have `payment_status = "paid"`.
+
+**Response `200`:**
+```json
+{
+  "message": "document regenerated"
+}
+```
+
+Use this after uploading an updated template. Generates a fresh document for the order using the current template.
+
+---
+
+## Approval Workflow
+
+This is the core admin feature. When a plan has `requires_approval = true`, orders under that plan will **not** auto-deliver documents after payment. Instead, they enter `review_pending` status and wait for an admin to approve.
+
+### How It Works
+
+```
+Customer pays
+    |
+    v
+Plan has requires_approval?
+    |               |
+   YES              NO
+    |               |
+    v               v
+Status: review_pending    Auto-generate doc + send email
+    |                         Status: available
+    v
+Admin reviews order in dashboard
+    |
+    v
+Admin clicks Approve
+    |
+    v
+Document generated + email sent
+Status: available
+```
+
+### Approve Order
+
+```
+POST /admin/orders/{order_id}/approve
+```
+
+**Auth:** Any admin role. Order must be in `review_pending` status.
+
+**Request Body (optional):**
+```json
+{
+  "admin_notes": "Approved after verifying company details."
+}
+```
+
+**Response `200`:** Full `AdminOrderDetailResponse` with updated status.
+
+**What happens on approve:**
+1. Records which admin approved and when (`reviewed_by_admin_id`, `reviewed_at`)
+2. Generates the document from the template
+3. Sends the delivery email to the customer
+4. Sets order status to `available` and records `completed_at`
+
+**Response `400`:** Order is not in `review_pending` status.
+
+---
+
+## Customers
+
+Read-only view of customers (the `users` table). Admins cannot modify customer data.
+
+### List Customers
+
+```
+GET /admin/customers
+```
+
+**Auth:** Any admin role.
+
+**Query Parameters:**
+
+| Param | Type | Default | Description |
+|-------|------|---------|-------------|
+| `page` | int | 1 | Page number |
+| `page_size` | int | 20 | Items per page (1-100) |
+| `query` | string | null | Search by email or full name |
+
+**Response `200`:**
+```json
+{
+  "items": [
+    {
+      "id": 5,
+      "email": "customer@example.com",
+      "full_name": "John Doe",
+      "created_at": "2026-03-15T10:00:00",
+      "last_login": "2026-04-05T09:30:00",
+      "order_count": 3
+    }
+  ],
+  "total": 45,
+  "page": 1,
+  "page_size": 20,
+  "total_pages": 3
+}
+```
+
+### Get Customer Detail
+
+```
+GET /admin/customers/{user_id}
+```
+
+**Auth:** Any admin role.
+
+**Response `200`:** Same shape as a single `AdminCustomerListItem` above.
+
+---
+
+## Plans
+
+### List Plans
+
+```
+GET /admin/plans
+```
+
+**Auth:** Any admin role.
+
+**Response `200`:**
+```json
+[
+  {
+    "id": 1,
+    "slug": "basic",
+    "name": "Basic",
+    "description": "Basic OHS manual",
+    "base_price": "99.99",
+    "requires_approval": false
+  },
+  {
+    "id": 2,
+    "slug": "comprehensive",
+    "name": "Comprehensive",
+    "description": "Comprehensive OHS manual",
+    "base_price": "199.99",
+    "requires_approval": true
+  }
+]
+```
+
+### Toggle Approval Setting
+
+```
+PATCH /admin/plans/{plan_id}/approval-setting
+```
+
+**Auth:** `owner` only. Returns `403` for `manager`/`support`.
+
+**Request Body:**
+```json
+{
+  "requires_approval": true
+}
+```
+
+**Response `200`:** Updated `AdminPlanResponse`.
+
+This controls whether orders under this plan auto-deliver or require admin approval. Changing this only affects **future** orders — existing orders keep their current status.
+
+---
+
+## Templates
+
+Document templates are `.docx` files used to generate customer documents. Each plan has one template named `{plan_slug}_manual_template.docx`.
+
+### List Templates
+
+```
+GET /admin/templates
+```
+
+**Auth:** Any admin role.
+
+**Response `200`:**
+```json
+[
+  {
+    "plan_slug": "basic",
+    "filename": "basic_manual_template.docx",
+    "file_size_bytes": 45678,
+    "last_modified": "2026-03-20T15:00:00"
+  },
+  {
+    "plan_slug": "comprehensive",
+    "filename": "comprehensive_manual_template.docx",
+    "file_size_bytes": 89012,
+    "last_modified": "2026-03-20T15:00:00"
+  }
+]
+```
+
+### Upload Template
+
+```
+POST /admin/templates/{plan_slug}
+```
+
+**Auth:** `owner` only.
+
+**Request:** `multipart/form-data` with a `file` field containing a `.docx` file.
+
+```
+Content-Type: multipart/form-data
+file: (binary .docx file)
+```
+
+**Response `200`:**
+```json
+{
+  "message": "template basic_manual_template.docx uploaded",
+  "filename": "basic_manual_template.docx"
+}
+```
+
+**Response `400`:** File is not `.docx`.
+
+After uploading a new template, use `POST /admin/orders/{order_id}/regenerate-document` to regenerate documents for specific orders that should use the updated template.
+
+### Download Template
+
+```
+GET /admin/templates/{plan_slug}/download
+```
+
+**Auth:** Any admin role.
+
+**Response `200`:** Binary `.docx` file download.
+
+**Response `404`:** Template not found.
+
+---
+
+## Dashboard Stats
+
+### Get Dashboard Stats
+
+```
+GET /admin/stats/dashboard
+```
+
+**Auth:** Any admin role.
+
+**Response `200`:**
+```json
+{
+  "total_revenue": "15249.50",
+  "total_orders": 203,
+  "orders_by_status": {
+    "draft": 12,
+    "processing": 3,
+    "review_pending": 5,
+    "available": 180,
+    "cancelled": 3
+  },
+  "orders_by_plan": {
+    "Basic": 120,
+    "Comprehensive": 83
+  },
+  "revenue_by_plan": {
+    "Basic": "5999.40",
+    "Comprehensive": "9250.10"
+  },
+  "pending_review_count": 5
+}
+```
+
+`pending_review_count` is useful for a notification badge on the dashboard — it tells the admin how many orders are waiting for approval.
+
+All monetary values are strings representing `Decimal` values in CAD.
+
+---
+
+## Email Logs
+
+### List Email Logs
+
+```
+GET /admin/logs/emails
+```
+
+**Auth:** Any admin role.
+
+**Query Parameters:**
+
+| Param | Type | Default | Description |
+|-------|------|---------|-------------|
+| `page` | int | 1 | Page number |
+| `page_size` | int | 20 | Items per page (1-100) |
+| `email_status` | string | null | Filter: `pending`, `sent`, `delivered`, `failed` |
+| `order_id` | int | null | Filter by order ID |
+
+**Response `200`:**
+```json
+{
+  "items": [
+    {
+      "id": 8,
+      "order_id": 42,
+      "recipient_email": "customer@example.com",
+      "subject": "Your documents are ready",
+      "status": "delivered",
+      "sent_at": "2026-04-01T14:36:00",
+      "failure_reason": null
+    }
+  ],
+  "total": 312,
+  "page": 1,
+  "page_size": 20,
+  "total_pages": 16
+}
+```
+
+---
+
+## Staff Management
+
+All staff endpoints require `owner` role. Non-owner admins get `403`.
+
+### List Admin Staff
+
+```
+GET /admin/staff
+```
+
+**Response `200`:**
+```json
+[
+  {
+    "id": 1,
+    "email": "admin@ohsremote.com",
+    "full_name": "System Admin",
+    "role": "owner",
+    "is_active": true,
+    "created_at": "2026-01-15T10:00:00",
+    "last_login": "2026-04-06T08:00:00"
+  },
+  {
+    "id": 2,
+    "email": "manager@ohsremote.com",
+    "full_name": "Jane Manager",
+    "role": "manager",
+    "is_active": true,
+    "created_at": "2026-02-01T10:00:00",
+    "last_login": "2026-04-05T14:30:00"
+  }
+]
+```
+
+### Create Admin Staff
+
+```
+POST /admin/staff
+```
+
+**Request Body:**
+```json
+{
+  "email": "newadmin@ohsremote.com",
+  "full_name": "New Admin",
+  "password": "secure_password_min_8",
+  "role": "manager"
+}
+```
+
+Valid roles: `owner`, `manager`, `support`.
+
+**Response `201`:** `AdminStaffListItem` of the created admin.
+
+**Response `400`:** Email already exists, invalid role, or password too short.
+
+### Deactivate Admin
+
+```
+PATCH /admin/staff/{admin_id}/deactivate
+```
+
+**Response `200`:** Updated `AdminStaffListItem` with `is_active: false`.
+
+**Response `400`:** Cannot deactivate your own account.
+
+Deactivated admins cannot log in. Their existing sessions are invalidated on next request.
+
+---
+
+## Enums & Constants
+
+### Order Status Values
+| Value | Description |
+|-------|-------------|
+| `draft` | Order created, payment not started |
+| `processing` | Payment received, being processed |
+| `review_pending` | Payment received, waiting for admin approval (when plan has `requires_approval = true`) |
+| `available` | Documents generated and delivered to customer |
+| `cancelled` | Order cancelled |
+
+### Payment Status Values
+| Value | Description |
+|-------|-------------|
+| `pending` | Awaiting payment |
+| `paid` | Payment confirmed via Stripe |
+| `failed` | Payment failed or checkout expired |
+| `refunded` | Payment refunded |
+
+### Email Status Values
+| Value | Description |
+|-------|-------------|
+| `pending` | Email queued |
+| `sent` | Email sent to SMTP server |
+| `delivered` | Email delivered successfully |
+| `failed` | Email delivery failed (check `failure_reason`) |
+
+### Admin Roles
+| Value | Description |
+|-------|-------------|
+| `owner` | Full access, can manage staff and settings |
+| `manager` | Can manage orders, customers, view stats |
+| `support` | Same access as manager |
+
+---
+
+## Error Handling
+
+All errors follow this format:
+
+```json
+{
+  "error": {
+    "code": "ERROR_CODE",
+    "message": "Human-readable description",
+    "details": {}
+  }
+}
+```
+
+### Common HTTP Status Codes
+
+| Status | Meaning |
+|--------|---------|
+| `200` | Success |
+| `201` | Created (staff creation) |
+| `400` | Bad request (validation error, invalid state) |
+| `401` | Not authenticated (missing or expired `admin_session` cookie) |
+| `403` | Forbidden (insufficient role, e.g., `manager` trying to access `owner`-only endpoint) |
+| `404` | Resource not found |
+| `422` | Request validation error (missing/malformed fields) |
+| `500` | Server error |
+
+---
+
+## Frontend Implementation Notes
+
+### Authentication Flow
+1. Show login form (email + password)
+2. `POST /admin/auth/login` — cookie is set automatically by the browser
+3. On app load, call `GET /admin/auth/me` to check if session is valid
+4. If `401`, redirect to login
+5. Store the admin's `role` from `/auth/me` to conditionally show owner-only features in the UI
+
+### Cookie Configuration
+The `admin_session` cookie is `httpOnly` so JavaScript cannot access it directly. The browser sends it automatically with every request. Make sure your HTTP client (axios, fetch) is configured with:
+- `credentials: "include"` (fetch)
+- `withCredentials: true` (axios)
+
+### Suggested Dashboard Layout
+1. **Top bar:** pending review count badge (from `GET /admin/stats/dashboard` → `pending_review_count`)
+2. **Main sections:**
+   - Orders table with filters (status, payment, plan, search)
+   - Pending Review queue (dedicated view with approve button)
+   - Customer list
+   - Stats/analytics cards
+3. **Settings area (owner only):**
+   - Plan approval toggles
+   - Template upload
+   - Staff management
+
+### Pagination Pattern
+All paginated endpoints follow the same pattern:
+```
+?page=1&page_size=20
+```
+Response always includes `total`, `page`, `page_size`, `total_pages` for building pagination controls.
+
+### OpenAPI / Swagger
+The full interactive API docs are available at:
+```
+{API_BASE_URL}/docs
+```
+All admin endpoints are tagged under `admin` and `admin-auth`. You can test requests directly from there.

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ stripe
 python-multipart
 python-jose
 passlib
+bcrypt


### PR DESCRIPTION
## What Changed

### Admin Panel API
- **Admin Authentication** (separate from customer auth)
  - Dedicated `admin_users` table with password-based login (bcrypt), completely isolated from customer users
  - HMAC-SHA256 session tokens with `ohs-admin-auth` audience — cross-system token rejection prevents customer→admin escalation
  - HTTP-only `admin_session` cookie (8hr expiry) separate from customer `auth_session` (1hr)
  - Role-based access: `owner`, `manager`, `support` with dependency-level enforcement

- **Order Management & Approval Workflow**
  - Configurable `requires_approval` flag on Plans — when enabled, paid orders land in `REVIEW_PENDING` instead of auto-delivering
  - Admin approval endpoint triggers fulfillment (document generation + email delivery)
  - Full order listing with filtering (status, plan, search query) and pagination
  - Document regeneration and email resend capabilities

- **Dashboard & Operational Endpoints**
  - Revenue stats: total revenue, order counts by status/plan
  - Customer listing (read-only) with order history
  - Email log viewing with status/order filtering
  - Template management (list, download, upload .docx templates)
  - Staff management (owner-only: create/deactivate admin users)

### Refactoring
- **OrderFulfillmentService extraction**
  - Consolidated duplicate document generation + email delivery logic from `webhooks.py` and `payments.py` into a single `OrderFulfillmentService`
  - Both webhook auto-delivery and admin approval use the same code path — no dual implementation

## Technical Details

**Key Implementation Notes:**
- 23 new admin endpoints across auth (`/admin/auth/*`) and operations (`/admin/*`)
- Alembic migration adds `admin_users` table, `requires_approval` to `plans`, and `reviewed_by_admin_id`/`reviewed_at` to `orders`
- `requires_approval` defaults to `false` with `server_default="0"` — existing plans continue auto-delivering with zero behavior change
- No order rejection flow — customers paid, so approval only reviews and releases documents
- Frontend API documentation in `docs/ADMIN_API.md`

**Testing:**
- Manual testing via frontend admin portal and Docker Compose
- Pre-existing test failures confirmed unrelated (enum string comparisons, import errors)